### PR TITLE
Add clang-format config and apply formatter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,78 @@
+---
+AccessModifierOffset: -4
+AlignAfterOpenBracket: DontAlign
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
+AlignOperands:   false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BasedOnStyle: None
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: All
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit:     120
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: true
+Language: Cpp
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 4
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SeparateDefinitionBlocks: Always
+SortIncludes:    CaseSensitive
+SpaceAfterCStyleCast: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: true
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        c++14
+TabWidth:        4
+UseTab:          Never
+...

--- a/cutlass_extensions/include/cutlass_extensions/arch/mma.h
+++ b/cutlass_extensions/include/cutlass_extensions/arch/mma.h
@@ -36,11 +36,13 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace cutlass {
-namespace arch {
+namespace cutlass
+{
+namespace arch
+{
 
 // Tag which triggers MMA which will trigger
 struct OpMultiplyAddDequantizeInterleavedBToA;
 
-}  // namespace arch
-}  // namespace cutlass
+} // namespace arch
+} // namespace cutlass

--- a/cutlass_extensions/include/cutlass_extensions/compute_occupancy.h
+++ b/cutlass_extensions/include/cutlass_extensions/compute_occupancy.h
@@ -20,18 +20,21 @@
 #include "cutlass/device_kernel.h"
 #include "utils/cuda_utils.h"
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
-template<typename GemmKernel>
+template <typename GemmKernel>
 inline int compute_occupancy_for_kernel()
 {
 
     int smem_size = int(sizeof(typename GemmKernel::SharedStorage));
 
-    if (smem_size > (48 << 10)) {
-        cudaError_t status =
-            cudaFuncSetAttribute(cutlass::Kernel<GemmKernel>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
-        if (status == cudaError::cudaErrorInvalidValue) {
+    if (smem_size > (48 << 10))
+    {
+        cudaError_t status
+            = cudaFuncSetAttribute(cutlass::Kernel<GemmKernel>, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size);
+        if (status == cudaError::cudaErrorInvalidValue)
+        {
             // Clear the error bit since we can ignore this.
             // This should mean that smem_size > cudaDevAttrMaxSharedMemoryPerBlockOptin. In that case, we return an
             // occupancy of 0. This will cause the heuristic to ignore this configuration.
@@ -48,4 +51,4 @@ inline int compute_occupancy_for_kernel()
     return max_active_blocks;
 }
 
-}  // namespace fastertransformer
+} // namespace fastertransformer

--- a/cutlass_extensions/include/cutlass_extensions/epilogue/epilogue_quant_helper.h
+++ b/cutlass_extensions/include/cutlass_extensions/epilogue/epilogue_quant_helper.h
@@ -33,16 +33,19 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace cutlass {
-namespace epilogue {
+namespace cutlass
+{
+namespace epilogue
+{
 
 // define scaling mode
-enum class QuantMode {
+enum class QuantMode
+{
     PerTensorQuant,
     PerTokenQuant,
     PerChannelQuant,
     PerTokenChannelQuant
 };
 
-}  // namespace epilogue
-}  // namespace cutlass
+} // namespace epilogue
+} // namespace cutlass

--- a/cutlass_extensions/include/cutlass_extensions/epilogue/thread/ft_fused_activations.h
+++ b/cutlass_extensions/include/cutlass_extensions/epilogue/thread/ft_fused_activations.h
@@ -45,9 +45,12 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace cutlass {
-namespace epilogue {
-namespace thread {
+namespace cutlass
+{
+namespace epilogue
+{
+namespace thread
+{
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -69,9 +72,11 @@ __forceinline__ __device__ float tanh_opt(float x)
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
-template<>
-struct GELU_taylor<float> {
+template <>
+struct GELU_taylor<float>
+{
     static const bool kIsHeavy = true;
+
     CUTLASS_DEVICE
     float operator()(float const& z) const
     {
@@ -79,8 +84,7 @@ struct GELU_taylor<float> {
         float k0 = float(0.7978845608028654);
         float k1 = float(0.044715);
 
-        return float(
-            cutlass::constants::half<float>() * z
+        return float(cutlass::constants::half<float>() * z
             * (cutlass::constants::one<float>() + tanh_opt(k0 * z * (cutlass::constants::one<float>() + k1 * z * z))));
     }
 
@@ -93,8 +97,8 @@ struct GELU_taylor<float> {
     }
 };
 
-}  // namespace thread
-}  // namespace epilogue
-}  // namespace cutlass
+} // namespace thread
+} // namespace epilogue
+} // namespace cutlass
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cutlass_extensions/include/cutlass_extensions/epilogue/threadblock/epilogue_per_row_per_col_scale.h
+++ b/cutlass_extensions/include/cutlass_extensions/epilogue/threadblock/epilogue_per_row_per_col_scale.h
@@ -46,80 +46,87 @@
 #include "cutlass/fast_math.h"
 #include "cutlass/numeric_conversion.h"
 
-namespace cutlass {
-namespace epilogue {
-namespace threadblock {
+namespace cutlass
+{
+namespace epilogue
+{
+namespace threadblock
+{
 
-template<typename ThreadblockShape_,
-         int ThreadCount,
-         typename ScaleTileIterator_,
-         typename OutputTileIterator_,
-         typename ElementAccumulator_,
-         typename ElementCompute_,
-         typename ElementwiseFunctor_,
-         bool UseMasking_ = false>
-class EpilogueVisitorPerRowPerCol {
+template <typename ThreadblockShape_, int ThreadCount, typename ScaleTileIterator_, typename OutputTileIterator_,
+    typename ElementAccumulator_, typename ElementCompute_, typename ElementwiseFunctor_, bool UseMasking_ = false>
+class EpilogueVisitorPerRowPerCol
+{
 public:
-    using ThreadblockShape        = ThreadblockShape_;
+    using ThreadblockShape = ThreadblockShape_;
     static int const kThreadCount = ThreadCount;
 
-    using ScaleTileIterator  = ScaleTileIterator_;
+    using ScaleTileIterator = ScaleTileIterator_;
     using OutputTileIterator = OutputTileIterator_;
     using ElementwiseFunctor = ElementwiseFunctor_;
 
-    static int const kIterations        = OutputTileIterator::kIterations;
+    static int const kIterations = OutputTileIterator::kIterations;
     static int const kElementsPerAccess = OutputTileIterator::kElementsPerAccess;
 
-    using ElementOutput      = typename OutputTileIterator::Element;
-    using LayoutOutput       = cutlass::layout::RowMajor;
+    using ElementOutput = typename OutputTileIterator::Element;
+    using LayoutOutput = cutlass::layout::RowMajor;
     using ElementAccumulator = ElementAccumulator_;
 
     using AlphaScaleElementType = typename ScaleTileIterator::Element;
 
-    using ElementCompute      = ElementCompute_;
+    using ElementCompute = ElementCompute_;
     using AccumulatorFragment = Array<ElementAccumulator, kElementsPerAccess>;
-    using ComputeFragment     = Array<ElementCompute_, kElementsPerAccess>;
-    using OutputVector        = Array<ElementOutput, kElementsPerAccess>;
+    using ComputeFragment = Array<ElementCompute_, kElementsPerAccess>;
+    using OutputVector = Array<ElementOutput, kElementsPerAccess>;
 
-    static int const  kThreadsPerRow      = OutputTileIterator::ThreadMap::Detail::kAccessWidth;
+    static int const kThreadsPerRow = OutputTileIterator::ThreadMap::Detail::kAccessWidth;
     static bool const kHasMultiStepsInRow = (OutputTileIterator::ThreadMap::Iterations::kColumn > 1);
 
     /// Argument structure
-    struct Arguments {
+    struct Arguments
+    {
 
         typename ElementwiseFunctor::Params elementwise;
-        int64_t                             batch_stride_alpha;
-        int64_t                             batch_stride_C;
-        int64_t                             batch_stride_D;
+        int64_t batch_stride_alpha;
+        int64_t batch_stride_C;
+        int64_t batch_stride_D;
 
         //
         // Methods
         //
-        Arguments(): batch_stride_alpha(0), batch_stride_C(0), batch_stride_D(0) {}
-
-        Arguments(typename ElementwiseFunctor::Params elementwise_):
-            elementwise(elementwise_), batch_stride_alpha(0), batch_stride_C(0), batch_stride_D(0)
+        Arguments()
+            : batch_stride_alpha(0)
+            , batch_stride_C(0)
+            , batch_stride_D(0)
         {
         }
 
-        Arguments(typename ElementwiseFunctor::Params elementwise_,
-                  int64_t                             batch_stride_alpha_,
-                  int64_t                             batch_stride_C_,
-                  int64_t                             batch_stride_D_):
-            elementwise(elementwise_),
-            batch_stride_alpha(batch_stride_alpha_),
-            batch_stride_C(batch_stride_C_),
-            batch_stride_D(batch_stride_D_)
+        Arguments(typename ElementwiseFunctor::Params elementwise_)
+            : elementwise(elementwise_)
+            , batch_stride_alpha(0)
+            , batch_stride_C(0)
+            , batch_stride_D(0)
+        {
+        }
+
+        Arguments(typename ElementwiseFunctor::Params elementwise_, int64_t batch_stride_alpha_,
+            int64_t batch_stride_C_, int64_t batch_stride_D_)
+            : elementwise(elementwise_)
+            , batch_stride_alpha(batch_stride_alpha_)
+            , batch_stride_C(batch_stride_C_)
+            , batch_stride_D(batch_stride_D_)
         {
         }
     };
 
-    struct Params {
+    struct Params
+    {
 
         typename ElementwiseFunctor::Params elementwise;
-        int64_t                             batch_stride_alpha;
-        int64_t                             batch_stride_C;
-        int64_t                             batch_stride_D;
+        int64_t batch_stride_alpha;
+        int64_t batch_stride_C;
+        int64_t batch_stride_D;
+
         //
         // Methods
         //
@@ -127,23 +134,25 @@ public:
         Params() {}
 
         CUTLASS_HOST_DEVICE
-        Params(Arguments const& args):
-            elementwise(args.elementwise),
-            batch_stride_alpha(args.batch_stride_alpha),
-            batch_stride_C(args.batch_stride_C),
-            batch_stride_D(args.batch_stride_D)
+        Params(Arguments const& args)
+            : elementwise(args.elementwise)
+            , batch_stride_alpha(args.batch_stride_alpha)
+            , batch_stride_C(args.batch_stride_C)
+            , batch_stride_D(args.batch_stride_D)
         {
         }
     };
 
     /// Shared storage
-    struct SharedStorage {};
+    struct SharedStorage
+    {
+    };
 
 private:
-    Params const&      params_;
-    SharedStorage&     shared_storage_;
-    MatrixCoord        extent_;
-    MatrixCoord        extent_real_;
+    Params const& params_;
+    SharedStorage& shared_storage_;
+    MatrixCoord extent_;
+    MatrixCoord extent_real_;
     ElementwiseFunctor elementwise_;
 
     const bool per_token_quant_;
@@ -151,13 +160,13 @@ private:
 
     AlphaScaleElementType* ptr_alpha_row_;
     AlphaScaleElementType* ptr_alpha_col_;
-    ScaleTileIterator      iterator_alpha_col_;
-    OutputTileIterator     iterator_C_;
-    OutputTileIterator     iterator_D_;
+    ScaleTileIterator iterator_alpha_col_;
+    OutputTileIterator iterator_C_;
+    OutputTileIterator iterator_D_;
 
-    AlphaScaleElementType                 element_alpha_row_ = 1.0f;
-    AlphaScaleElementType                 element_alpha_col_ = 1.0f;
-    typename ScaleTileIterator::Fragment  fragment_alpha_col_;
+    AlphaScaleElementType element_alpha_row_ = 1.0f;
+    AlphaScaleElementType element_alpha_col_ = 1.0f;
+    typename ScaleTileIterator::Fragment fragment_alpha_col_;
     typename OutputTileIterator::Fragment fragment_C_;
     typename OutputTileIterator::Fragment fragment_D_;
 
@@ -169,48 +178,40 @@ private:
 
 public:
     CUTLASS_DEVICE
-    EpilogueVisitorPerRowPerCol(Params const&                         params,
-                                SharedStorage&                        shared_storage,
-                                cutlass::MatrixCoord const&           problem_size,
-                                int                                   thread_idx,
-                                int                                   warp_idx,
-                                int                                   lane_idx,
-                                typename ScaleTileIterator::Params    params_alpha_col,
-                                typename OutputTileIterator::Params   params_C,
-                                typename OutputTileIterator::Params   params_D,
-                                QuantMode                             quant_mode,
-                                AlphaScaleElementType*                ptr_alpha_row,
-                                AlphaScaleElementType*                ptr_alpha_col,
-                                typename OutputTileIterator::Element* ptr_C,
-                                typename OutputTileIterator::Element* ptr_D,
-                                cutlass::MatrixCoord const&           threadblock_offset = cutlass::MatrixCoord(0, 0),
-                                int                                   column_offset      = 0,
-                                cutlass::MatrixCoord const&           problem_size_real  = cutlass::MatrixCoord(0, 0)):
-        params_(params),
-        shared_storage_(shared_storage),
-        extent_(problem_size),
-        elementwise_(params.elementwise),
-        per_token_quant_(quant_mode == QuantMode::PerTokenQuant || quant_mode == QuantMode::PerTokenChannelQuant),
-        per_channel_quant_(quant_mode == QuantMode::PerChannelQuant || quant_mode == QuantMode::PerTokenChannelQuant),
-        ptr_alpha_row_(ptr_alpha_row),
-        ptr_alpha_col_(ptr_alpha_col),
-        iterator_alpha_col_(params_alpha_col, ptr_alpha_col, problem_size, thread_idx, threadblock_offset),
-        iterator_C_(params_C, ptr_C, problem_size, thread_idx, threadblock_offset),
-        iterator_D_(params_D, ptr_D, problem_size, thread_idx, threadblock_offset),
-        extent_real_(problem_size_real)
+    EpilogueVisitorPerRowPerCol(Params const& params, SharedStorage& shared_storage,
+        cutlass::MatrixCoord const& problem_size, int thread_idx, int warp_idx, int lane_idx,
+        typename ScaleTileIterator::Params params_alpha_col, typename OutputTileIterator::Params params_C,
+        typename OutputTileIterator::Params params_D, QuantMode quant_mode, AlphaScaleElementType* ptr_alpha_row,
+        AlphaScaleElementType* ptr_alpha_col, typename OutputTileIterator::Element* ptr_C,
+        typename OutputTileIterator::Element* ptr_D,
+        cutlass::MatrixCoord const& threadblock_offset = cutlass::MatrixCoord(0, 0), int column_offset = 0,
+        cutlass::MatrixCoord const& problem_size_real = cutlass::MatrixCoord(0, 0))
+        : params_(params)
+        , shared_storage_(shared_storage)
+        , extent_(problem_size)
+        , elementwise_(params.elementwise)
+        , per_token_quant_(quant_mode == QuantMode::PerTokenQuant || quant_mode == QuantMode::PerTokenChannelQuant)
+        , per_channel_quant_(quant_mode == QuantMode::PerChannelQuant || quant_mode == QuantMode::PerTokenChannelQuant)
+        , ptr_alpha_row_(ptr_alpha_row)
+        , ptr_alpha_col_(ptr_alpha_col)
+        , iterator_alpha_col_(params_alpha_col, ptr_alpha_col, problem_size, thread_idx, threadblock_offset)
+        , iterator_C_(params_C, ptr_C, problem_size, thread_idx, threadblock_offset)
+        , iterator_D_(params_D, ptr_D, problem_size, thread_idx, threadblock_offset)
+        , extent_real_(problem_size_real)
     {
         beta_ = (params.elementwise.beta_ptr ? *params.elementwise.beta_ptr : params.elementwise.beta);
 
-        if (beta_ == ElementAccumulator()) {
+        if (beta_ == ElementAccumulator())
+        {
             iterator_C_.clear_mask();
         }
     }
 
     /// Helper to indicate split-K behavior
     CUTLASS_DEVICE
-    void set_k_partition(int split_k_index,  ///< Index of this threadblock within split-K partitioned scheme
-                         int split_k_slices)
-    {  ///< Total number of split-K slices
+    void set_k_partition(int split_k_index, ///< Index of this threadblock within split-K partitioned scheme
+        int split_k_slices)
+    { ///< Total number of split-K slices
     }
 
     /// Called to set the batch index
@@ -226,15 +227,18 @@ public:
     CUTLASS_DEVICE
     void begin_epilogue()
     {
-        if (per_channel_quant_) {
+        if (per_channel_quant_)
+        {
             iterator_alpha_col_.load(fragment_alpha_col_);
         }
-        else if (ptr_alpha_col_ != nullptr) {
+        else if (ptr_alpha_col_ != nullptr)
+        {
             arch::global_load<AlphaScaleElementType, sizeof(AlphaScaleElementType)>(
                 element_alpha_col_, ptr_alpha_col_, true);
         }
 
-        if (!per_token_quant_ && ptr_alpha_row_ != nullptr) {
+        if (!per_token_quant_ && ptr_alpha_row_ != nullptr)
+        {
             arch::global_load<AlphaScaleElementType, sizeof(AlphaScaleElementType)>(
                 element_alpha_row_, ptr_alpha_row_, true);
         }
@@ -247,15 +251,17 @@ public:
         fragment_D_.clear();
         fragment_C_.clear();
 
-        if (elementwise_.kScale != cutlass::epilogue::thread::ScaleType::OnlyAlphaScaling) {
+        if (elementwise_.kScale != cutlass::epilogue::thread::ScaleType::OnlyAlphaScaling)
+        {
             iterator_C_.load(fragment_C_);
             ++iterator_C_;
         }
 
         // load alpha_row in begin_step only when per token(row) scaling is used
-        if (per_token_quant_) {
-            int thread_offset_row =
-                iterator_D_.thread_start_row() + OutputTileIterator::ThreadMap::iteration_offset(0).row();
+        if (per_token_quant_)
+        {
+            int thread_offset_row
+                = iterator_D_.thread_start_row() + OutputTileIterator::ThreadMap::iteration_offset(0).row();
 
             // element_alpha_row_ = ptr_alpha_row_[thread_offset_row];
             arch::global_load<AlphaScaleElementType, sizeof(AlphaScaleElementType)>(
@@ -278,11 +284,13 @@ public:
         NumericArrayConverter<ElementCompute, ElementAccumulator, kElementsPerAccess> source_converter;
 
         ComputeFragment result = source_converter(accum);
-        if (per_channel_quant_) {
+        if (per_channel_quant_)
+        {
             ComputeFragment alpha_col = reinterpret_cast<ComputeFragment*>(&fragment_alpha_col_)[frag_idx];
-            result                    = per_token_channel_scale_accumulator_(result, alpha_col, element_alpha_row_);
+            result = per_token_channel_scale_accumulator_(result, alpha_col, element_alpha_row_);
         }
-        else {
+        else
+        {
             result = per_token_scale_accumulator_(result, element_alpha_col_, element_alpha_row_);
         }
 
@@ -298,7 +306,7 @@ public:
         /* // Convert to the output */
         NumericArrayConverter<ElementOutput, ElementCompute, kElementsPerAccess> output_converter;
         OutputVector& output = reinterpret_cast<OutputVector*>(&fragment_D_)[frag_idx];
-        output               = output_converter(result);
+        output = output_converter(result);
     }
 
     /// Called at the end of a row
@@ -355,14 +363,14 @@ public:
 
 private:
     CUTLASS_DEVICE
-    ComputeFragment per_token_channel_scale_accumulator_(ComputeFragment const&       accum,
-                                                         ComputeFragment const&       scale_col,
-                                                         AlphaScaleElementType const& scale_row)
+    ComputeFragment per_token_channel_scale_accumulator_(
+        ComputeFragment const& accum, ComputeFragment const& scale_col, AlphaScaleElementType const& scale_row)
     {
 
         ComputeFragment result;
         CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < ComputeFragment::kElements; ++i) {
+        for (int i = 0; i < ComputeFragment::kElements; ++i)
+        {
             result[i] = accum[i] * (scale_col[i] * scale_row);
         }
 
@@ -370,14 +378,14 @@ private:
     }
 
     CUTLASS_DEVICE
-    ComputeFragment per_token_scale_accumulator_(ComputeFragment const&       accum,
-                                                 AlphaScaleElementType const& scale_col,
-                                                 AlphaScaleElementType const& scale_row)
+    ComputeFragment per_token_scale_accumulator_(
+        ComputeFragment const& accum, AlphaScaleElementType const& scale_col, AlphaScaleElementType const& scale_row)
     {
 
         ComputeFragment result;
         CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < ComputeFragment::kElements; ++i) {
+        for (int i = 0; i < ComputeFragment::kElements; ++i)
+        {
             result[i] = accum[i] * (scale_col * scale_row);
         }
 
@@ -385,6 +393,6 @@ private:
     }
 };
 
-}  // namespace threadblock
-}  // namespace epilogue
-}  // namespace cutlass
+} // namespace threadblock
+} // namespace epilogue
+} // namespace cutlass

--- a/cutlass_extensions/include/cutlass_extensions/epilogue/threadblock/epilogue_tensor_op_int32.h
+++ b/cutlass_extensions/include/cutlass_extensions/epilogue/threadblock/epilogue_tensor_op_int32.h
@@ -80,20 +80,25 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace cutlass {
-namespace epilogue {
-namespace threadblock {
+namespace cutlass
+{
+namespace epilogue
+{
+namespace threadblock
+{
 
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace detail {
+namespace detail
+{
 
 /// Partial specialization for half <= int32_t x 8 epilogues avoids shared memory bank conflicts.
-template<typename ThreadblockShape, typename WarpShape, typename InstructionShape, typename ThreadMap>
-struct DefaultIteratorsTensorOp<cutlass::half_t, int32_t, 8, ThreadblockShape, WarpShape, InstructionShape, ThreadMap> {
+template <typename ThreadblockShape, typename WarpShape, typename InstructionShape, typename ThreadMap>
+struct DefaultIteratorsTensorOp<cutlass::half_t, int32_t, 8, ThreadblockShape, WarpShape, InstructionShape, ThreadMap>
+{
 
-    using WarpTileIterator =
-        cutlass::epilogue::warp::TileIteratorTensorOp<WarpShape, InstructionShape, int32_t, layout::RowMajor>;
+    using WarpTileIterator
+        = cutlass::epilogue::warp::TileIteratorTensorOp<WarpShape, InstructionShape, int32_t, layout::RowMajor>;
 
     using SharedLoadIterator = cutlass::epilogue::threadblock::SharedLoadIterator<ThreadMap, int32_t>;
 
@@ -101,17 +106,13 @@ struct DefaultIteratorsTensorOp<cutlass::half_t, int32_t, 8, ThreadblockShape, W
 };
 
 /// Partial specialization for bfloat16_t <= int32_t x 8 epilogues avoids shared memory bank conflicts.
-template<typename ThreadblockShape, typename WarpShape, typename InstructionShape, typename ThreadMap>
-struct DefaultIteratorsTensorOp<cutlass::bfloat16_t,
-                                int32_t,
-                                8,
-                                ThreadblockShape,
-                                WarpShape,
-                                InstructionShape,
-                                ThreadMap> {
+template <typename ThreadblockShape, typename WarpShape, typename InstructionShape, typename ThreadMap>
+struct DefaultIteratorsTensorOp<cutlass::bfloat16_t, int32_t, 8, ThreadblockShape, WarpShape, InstructionShape,
+    ThreadMap>
+{
 
-    using WarpTileIterator =
-        cutlass::epilogue::warp::TileIteratorTensorOp<WarpShape, InstructionShape, int32_t, layout::RowMajor>;
+    using WarpTileIterator
+        = cutlass::epilogue::warp::TileIteratorTensorOp<WarpShape, InstructionShape, int32_t, layout::RowMajor>;
 
     using SharedLoadIterator = cutlass::epilogue::threadblock::SharedLoadIterator<ThreadMap, int32_t>;
 
@@ -120,7 +121,7 @@ struct DefaultIteratorsTensorOp<cutlass::bfloat16_t,
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-}  // namespace detail
+} // namespace detail
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -128,21 +129,22 @@ struct DefaultIteratorsTensorOp<cutlass::bfloat16_t,
 ///
 /// Satisfies: ReadableTileIterator
 ///
-template<typename ThreadMap_  ///< Thread map (conept: OutputTileThreadMap)
-         >
-class SharedLoadIteratorMixed<ThreadMap_, int32_t, 32, 16, 8, 8> {
+template <typename ThreadMap_ ///< Thread map (conept: OutputTileThreadMap)
+    >
+class SharedLoadIteratorMixed<ThreadMap_, int32_t, 32, 16, 8, 8>
+{
 public:
     using ThreadMap = ThreadMap_;
-    using Shape     = typename ThreadMap::Shape;
+    using Shape = typename ThreadMap::Shape;
 
     using Element = int32_t;
 
-    using Layout         = layout::RowMajor;
-    using TensorRef      = TensorRef<Element, Layout>;
+    using Layout = layout::RowMajor;
+    using TensorRef = TensorRef<Element, Layout>;
     using ConstTensorRef = typename TensorRef::ConstTensorRef;
 
-    using Index       = typename Layout::Index;
-    using LongIndex   = typename Layout::LongIndex;
+    using Index = typename Layout::Index;
+    using LongIndex = typename Layout::LongIndex;
     using TensorCoord = MatrixCoord;
 
     static int const kElementsPerAccess = ThreadMap::kElementsPerAccess;
@@ -153,16 +155,15 @@ public:
 
     /// Fragment object
     using Fragment = Array<Element,
-                           ThreadMap::Iterations::kColumn * ThreadMap::Iterations::kRow * ThreadMap::Iterations::kGroup
-                               * ThreadMap::Iterations::kCluster * ThreadMap::kElementsPerAccess>;
+        ThreadMap::Iterations::kColumn * ThreadMap::Iterations::kRow * ThreadMap::Iterations::kGroup
+            * ThreadMap::Iterations::kCluster * ThreadMap::kElementsPerAccess>;
 
     /// Memory access size
     using AccessType = AlignedArray<Element, ThreadMap::kElementsPerAccess, kAlignment>;
 
     /// Vector type used for SMEM loads
-    using LoadType = AlignedArray<Element,
-                                  const_min(128 / sizeof_bits<Element>::value, ThreadMap::kElementsPerAccess),
-                                  const_min(16, kAlignment)>;
+    using LoadType = AlignedArray<Element, const_min(128 / sizeof_bits<Element>::value, ThreadMap::kElementsPerAccess),
+        const_min(16, kAlignment)>;
 
     static int const kLoadsPerAccess = AccessType::kElements / LoadType::kElements;
 
@@ -184,17 +185,19 @@ public:
 
     /// Constructor
     CUTLASS_DEVICE
-    SharedLoadIteratorMixed(TensorRef ref, int thread_idx): stride_((ref.stride(0) / LoadType::kElements))
+    SharedLoadIteratorMixed(TensorRef ref, int thread_idx)
+        : stride_((ref.stride(0) / LoadType::kElements))
     {
 
         TensorCoord thread_offset = ThreadMap::initial_offset(thread_idx);
 
         // Initialize pointers
         CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < kLoadsPerAccess; ++i) {
+        for (int i = 0; i < kLoadsPerAccess; ++i)
+        {
             pointers_[i] = reinterpret_cast<LoadType const*>(ref.data());
 
-            int col_idx     = (thread_offset.column() / kElementsPerAccess) * kLoadsPerAccess;
+            int col_idx = (thread_offset.column() / kElementsPerAccess) * kLoadsPerAccess;
             int bank_offset = (col_idx * int(sizeof(LoadType)) / 128) % kLoadsPerAccess;
 
             col_idx += (bank_offset + i) % kLoadsPerAccess;
@@ -208,7 +211,8 @@ public:
     void add_pointer_offset(LongIndex pointer_offset)
     {
         CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < kLoadsPerAccess; ++i) {
+        for (int i = 0; i < kLoadsPerAccess; ++i)
+        {
             pointers_[i] += pointer_offset / LoadType::kElements;
         }
     }
@@ -217,9 +221,10 @@ public:
     void add_tile_offset(TensorCoord const& offset)
     {
         CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < kLoadsPerAccess; ++i) {
-            pointers_[i] +=
-                offset.row() * Shape::kRow * stride_ + offset.column() * Shape::kColumn / LoadType::kElements;
+        for (int i = 0; i < kLoadsPerAccess; ++i)
+        {
+            pointers_[i]
+                += offset.row() * Shape::kRow * stride_ + offset.column() * Shape::kColumn / LoadType::kElements;
         }
     }
 
@@ -229,33 +234,38 @@ public:
     {
 
         CUTLASS_PRAGMA_UNROLL
-        for (int cluster = 0; cluster < ThreadMap::Iterations::kCluster; ++cluster) {
+        for (int cluster = 0; cluster < ThreadMap::Iterations::kCluster; ++cluster)
+        {
 
             CUTLASS_PRAGMA_UNROLL
-            for (int group = 0; group < ThreadMap::Iterations::kGroup; ++group) {
+            for (int group = 0; group < ThreadMap::Iterations::kGroup; ++group)
+            {
 
                 CUTLASS_PRAGMA_UNROLL
-                for (int row = 0; row < ThreadMap::Iterations::kRow; ++row) {
+                for (int row = 0; row < ThreadMap::Iterations::kRow; ++row)
+                {
 
-                    int row_ptr_offset =
-                        row * ThreadMap::Delta::kRow * stride_ + group * ThreadMap::Delta::kGroup * stride_
-                        + cluster * ThreadMap::Delta::kCluster * stride_ + pointer_offset / LoadType::kElements;
+                    int row_ptr_offset = row * ThreadMap::Delta::kRow * stride_
+                        + group * ThreadMap::Delta::kGroup * stride_ + cluster * ThreadMap::Delta::kCluster * stride_
+                        + pointer_offset / LoadType::kElements;
 
-                    int frag_row_idx =
-                        (row + ThreadMap::Iterations::kRow * (group + ThreadMap::Iterations::kGroup * cluster));
+                    int frag_row_idx
+                        = (row + ThreadMap::Iterations::kRow * (group + ThreadMap::Iterations::kGroup * cluster));
 
                     LoadType* frag_ptr = reinterpret_cast<LoadType*>(&frag);
 
                     CUTLASS_PRAGMA_UNROLL
-                    for (int column = 0; column < ThreadMap::Iterations::kColumn; ++column) {
+                    for (int column = 0; column < ThreadMap::Iterations::kColumn; ++column)
+                    {
 
                         int frag_idx = frag_row_idx * ThreadMap::Iterations::kColumn + column;
 
                         CUTLASS_PRAGMA_UNROLL
-                        for (int v = 0; v < kLoadsPerAccess; ++v) {
+                        for (int v = 0; v < kLoadsPerAccess; ++v)
+                        {
 
-                            int vector_idx =
-                                (column * ThreadMap::Delta::kColumn / kElementsPerAccess * kLoadsPerAccess);
+                            int vector_idx
+                                = (column * ThreadMap::Delta::kColumn / kElementsPerAccess * kLoadsPerAccess);
 
                             LoadType const* memory_pointer = pointers_[v] + row_ptr_offset;
 
@@ -278,8 +288,8 @@ public:
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-}  // namespace threadblock
-}  // namespace epilogue
-}  // namespace cutlass
+} // namespace threadblock
+} // namespace epilogue
+} // namespace cutlass
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cutlass_extensions/include/cutlass_extensions/epilogue_helpers.h
+++ b/cutlass_extensions/include/cutlass_extensions/epilogue_helpers.h
@@ -15,68 +15,68 @@
 #include "cutlass/epilogue/thread/linear_combination_silu.h"
 #include "cutlass_extensions/epilogue/thread/ft_fused_activations.h"
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
-struct EpilogueOpBiasSilu {};
-
-struct EpilogueOpBiasReLU {};
-
-struct EpilogueOpBiasFtGelu {};
-
-struct EpilogueOpBias {};
-
-struct EpilogueOpNoBias {};
-
-template<typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator, typename Op>
-struct Epilogue {
+struct EpilogueOpBiasSilu
+{
 };
 
-template<typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator>
-struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, EpilogueOpBiasSilu> {
-    using Op = cutlass::epilogue::thread::LinearCombinationSilu<ElementType,
-                                                                ElementsPerVectorAccess,
-                                                                ElementAccumulator,
-                                                                ElementAccumulator,
-                                                                cutlass::epilogue::thread::ScaleType::NoBetaScaling>;
+struct EpilogueOpBiasReLU
+{
 };
 
-template<typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator>
-struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, EpilogueOpBiasReLU> {
-    using Op = cutlass::epilogue::thread::LinearCombinationRelu<ElementType,
-                                                                ElementsPerVectorAccess,
-                                                                ElementAccumulator,
-                                                                ElementAccumulator,
-                                                                cutlass::epilogue::thread::ScaleType::NoBetaScaling>;
+struct EpilogueOpBiasFtGelu
+{
 };
 
-template<typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator>
-struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, EpilogueOpBiasFtGelu> {
-    using Op = cutlass::epilogue::thread::LinearCombinationGeneric<cutlass::epilogue::thread::GELU_taylor,
-                                                                   ElementType,
-                                                                   ElementsPerVectorAccess,
-                                                                   ElementAccumulator,
-                                                                   ElementAccumulator,
-                                                                   cutlass::epilogue::thread::ScaleType::NoBetaScaling,
-                                                                   cutlass::FloatRoundStyle::round_to_nearest,
-                                                                   true>;
+struct EpilogueOpBias
+{
 };
 
-template<typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator>
-struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, EpilogueOpBias> {
-    using Op = cutlass::epilogue::thread::LinearCombination<ElementType,
-                                                            ElementsPerVectorAccess,
-                                                            ElementAccumulator,
-                                                            ElementAccumulator,
-                                                            cutlass::epilogue::thread::ScaleType::NoBetaScaling>;
+struct EpilogueOpNoBias
+{
 };
 
-template<typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator>
-struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, EpilogueOpNoBias> {
-    using Op = cutlass::epilogue::thread::LinearCombination<ElementType,
-                                                            ElementsPerVectorAccess,
-                                                            ElementAccumulator,
-                                                            ElementAccumulator,
-                                                            cutlass::epilogue::thread::ScaleType::Default>;
+template <typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator, typename Op>
+struct Epilogue
+{
 };
 
-}  // namespace fastertransformer
+template <typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator>
+struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, EpilogueOpBiasSilu>
+{
+    using Op = cutlass::epilogue::thread::LinearCombinationSilu<ElementType, ElementsPerVectorAccess,
+        ElementAccumulator, ElementAccumulator, cutlass::epilogue::thread::ScaleType::NoBetaScaling>;
+};
+
+template <typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator>
+struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, EpilogueOpBiasReLU>
+{
+    using Op = cutlass::epilogue::thread::LinearCombinationRelu<ElementType, ElementsPerVectorAccess,
+        ElementAccumulator, ElementAccumulator, cutlass::epilogue::thread::ScaleType::NoBetaScaling>;
+};
+
+template <typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator>
+struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, EpilogueOpBiasFtGelu>
+{
+    using Op = cutlass::epilogue::thread::LinearCombinationGeneric<cutlass::epilogue::thread::GELU_taylor, ElementType,
+        ElementsPerVectorAccess, ElementAccumulator, ElementAccumulator,
+        cutlass::epilogue::thread::ScaleType::NoBetaScaling, cutlass::FloatRoundStyle::round_to_nearest, true>;
+};
+
+template <typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator>
+struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, EpilogueOpBias>
+{
+    using Op = cutlass::epilogue::thread::LinearCombination<ElementType, ElementsPerVectorAccess, ElementAccumulator,
+        ElementAccumulator, cutlass::epilogue::thread::ScaleType::NoBetaScaling>;
+};
+
+template <typename ElementType, int ElementsPerVectorAccess, typename ElementAccumulator>
+struct Epilogue<ElementType, ElementsPerVectorAccess, ElementAccumulator, EpilogueOpNoBias>
+{
+    using Op = cutlass::epilogue::thread::LinearCombination<ElementType, ElementsPerVectorAccess, ElementAccumulator,
+        ElementAccumulator, cutlass::epilogue::thread::ScaleType::Default>;
+};
+
+} // namespace fastertransformer

--- a/cutlass_extensions/include/cutlass_extensions/ft_gemm_configs.h
+++ b/cutlass_extensions/include/cutlass_extensions/ft_gemm_configs.h
@@ -16,10 +16,12 @@
 
 #pragma once
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 // Note: The shapes are in the format MxNxK. The K shape of the runtime config MUST match the K shape
 //       in the kernel layout details when doing weight only quantization.
-enum class CutlassTileConfig {
+enum class CutlassTileConfig
+{
     // Signals that we should run heuristics do choose a config
     Undefined,
 
@@ -42,17 +44,19 @@ enum class CutlassTileConfig {
     CtaShape128x128x64_WarpShape128x32x64
 };
 
-enum class SplitKStyle {
+enum class SplitKStyle
+{
     NO_SPLIT_K,
     SPLIT_K_SERIAL,
     // SPLIT_K_PARALLEL // Not supported yet
 };
 
-struct CutlassGemmConfig {
-    CutlassTileConfig tile_config    = CutlassTileConfig::ChooseWithHeuristic;
-    SplitKStyle       split_k_style  = SplitKStyle::NO_SPLIT_K;
-    int               split_k_factor = -1;
-    int               stages         = -1;
+struct CutlassGemmConfig
+{
+    CutlassTileConfig tile_config = CutlassTileConfig::ChooseWithHeuristic;
+    SplitKStyle split_k_style = SplitKStyle::NO_SPLIT_K;
+    int split_k_factor = -1;
+    int stages = -1;
 };
 
-}  // namespace fastertransformer
+} // namespace fastertransformer

--- a/cutlass_extensions/include/cutlass_extensions/gemm/kernel/default_fpA_intB_traits.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/kernel/default_fpA_intB_traits.h
@@ -10,26 +10,31 @@
 #include "cutlass_extensions/arch/mma.h"
 #include "cutlass_extensions/gemm/kernel/mixed_gemm_B_layout.h"
 
-namespace cutlass {
-namespace gemm {
-namespace kernel {
+namespace cutlass
+{
+namespace gemm
+{
+namespace kernel
+{
 
-template<typename TypeA, typename TypeB, typename arch, typename Enable = void>
-struct MixedGemmArchTraits {
+template <typename TypeA, typename TypeB, typename arch, typename Enable = void>
+struct MixedGemmArchTraits
+{
 };
 
-template<typename arch>
-struct MixedGemmArchTraits<float, float, arch> {
+template <typename arch>
+struct MixedGemmArchTraits<float, float, arch>
+{
     static constexpr int Stages = 2;
-    using OperatorClass         = cutlass::arch::OpClassSimt;
-    using AccType               = float;
-    using LayoutB               = cutlass::layout::RowMajor;
+    using OperatorClass = cutlass::arch::OpClassSimt;
+    using AccType = float;
+    using LayoutB = cutlass::layout::RowMajor;
 
     static constexpr int ElementsPerAccessA = 1;
     static constexpr int ElementsPerAccessB = 1;
     static constexpr int ElementsPerAccessC = 1;
-    static constexpr int ThreadblockK       = 8;
-    using InstructionShape                  = cutlass::gemm::GemmShape<1, 1, 1>;
+    static constexpr int ThreadblockK = 8;
+    using InstructionShape = cutlass::gemm::GemmShape<1, 1, 1>;
 
     using Operator = cutlass::arch::OpMultiplyAdd;
 };
@@ -39,13 +44,11 @@ struct MixedGemmArchTraits<float, float, arch> {
 // This will instantiate any HMMA tensorcore kernels for Volta.
 // Note that volta does not have native bfloat support so weights and activations will be casted to fp16
 // and compute will happen in fp16 then will be converted for bf16 output.
-template<typename TypeA, typename TypeB>
-struct MixedGemmArchTraits<
-    TypeA,
-    TypeB,
-    cutlass::arch::Sm70,
+template <typename TypeA, typename TypeB>
+struct MixedGemmArchTraits<TypeA, TypeB, cutlass::arch::Sm70,
     typename cutlass::platform::enable_if<cutlass::platform::is_same<TypeA, cutlass::half_t>::value
-                                          || cutlass::platform::is_same<TypeA, cutlass::bfloat16_t>::value>::type> {
+        || cutlass::platform::is_same<TypeA, cutlass::bfloat16_t>::value>::type>
+{
 private:
     using LayoutDetails = LayoutDetailsB<TypeB, cutlass::arch::Sm70>;
 
@@ -53,13 +56,13 @@ public:
     static constexpr int ThreadblockK = LayoutDetails::ThreadblockK;
 
     using OperatorClass = cutlass::arch::OpClassTensorOp;
-    using AccType       = float;
-    using LayoutB       = typename LayoutDetails::Layout;
+    using AccType = float;
+    using LayoutB = typename LayoutDetails::Layout;
 
     static constexpr int ElementsPerAccessA = 128 / cutlass::sizeof_bits<TypeA>::value;
     static constexpr int ElementsPerAccessB = LayoutDetails::ElementsPerAccess;
     static constexpr int ElementsPerAccessC = 128 / cutlass::sizeof_bits<TypeA>::value;
-    using InstructionShape                  = cutlass::gemm::GemmShape<8, 8, 4>;
+    using InstructionShape = cutlass::gemm::GemmShape<8, 8, 4>;
 
     using Operator = typename LayoutDetails::Operator;
 };
@@ -67,13 +70,11 @@ public:
 // ======================= Turing Traits ==============================
 // Note that turing does not have native bfloat support so weights and activations will be casted to fp16
 // and compute will happen in fp16 then will be converted for bf16 output.
-template<typename TypeA, typename TypeB>
-struct MixedGemmArchTraits<
-    TypeA,
-    TypeB,
-    cutlass::arch::Sm75,
+template <typename TypeA, typename TypeB>
+struct MixedGemmArchTraits<TypeA, TypeB, cutlass::arch::Sm75,
     typename cutlass::platform::enable_if<cutlass::platform::is_same<TypeA, cutlass::half_t>::value
-                                          || cutlass::platform::is_same<TypeA, cutlass::bfloat16_t>::value>::type> {
+        || cutlass::platform::is_same<TypeA, cutlass::bfloat16_t>::value>::type>
+{
 private:
     using LayoutDetails = LayoutDetailsB<TypeB, cutlass::arch::Sm75>;
 
@@ -81,25 +82,23 @@ public:
     static constexpr int ThreadblockK = LayoutDetails::ThreadblockK;
 
     using OperatorClass = cutlass::arch::OpClassTensorOp;
-    using AccType       = float;
-    using LayoutB       = typename LayoutDetails::Layout;
+    using AccType = float;
+    using LayoutB = typename LayoutDetails::Layout;
 
     static constexpr int ElementsPerAccessA = 128 / cutlass::sizeof_bits<TypeA>::value;
     static constexpr int ElementsPerAccessB = LayoutDetails::ElementsPerAccess;
     static constexpr int ElementsPerAccessC = 128 / cutlass::sizeof_bits<TypeA>::value;
-    using InstructionShape                  = cutlass::gemm::GemmShape<16, 8, 8>;
+    using InstructionShape = cutlass::gemm::GemmShape<16, 8, 8>;
 
     using Operator = typename LayoutDetails::Operator;
 };
 
 // ======================= Ampere Traits ==============================
-template<typename TypeA, typename TypeB>
-struct MixedGemmArchTraits<
-    TypeA,
-    TypeB,
-    cutlass::arch::Sm80,
+template <typename TypeA, typename TypeB>
+struct MixedGemmArchTraits<TypeA, TypeB, cutlass::arch::Sm80,
     typename cutlass::platform::enable_if<cutlass::platform::is_same<TypeA, cutlass::half_t>::value
-                                          || cutlass::platform::is_same<TypeA, cutlass::bfloat16_t>::value>::type> {
+        || cutlass::platform::is_same<TypeA, cutlass::bfloat16_t>::value>::type>
+{
 private:
     using LayoutDetails = LayoutDetailsB<TypeB, cutlass::arch::Sm80>;
 
@@ -107,17 +106,17 @@ public:
     static constexpr int ThreadblockK = LayoutDetails::ThreadblockK;
 
     using OperatorClass = cutlass::arch::OpClassTensorOp;
-    using AccType       = float;
-    using LayoutB       = typename LayoutDetails::Layout;
+    using AccType = float;
+    using LayoutB = typename LayoutDetails::Layout;
 
     static constexpr int ElementsPerAccessA = 128 / cutlass::sizeof_bits<TypeA>::value;
     static constexpr int ElementsPerAccessB = LayoutDetails::ElementsPerAccess;
     static constexpr int ElementsPerAccessC = 128 / cutlass::sizeof_bits<TypeA>::value;
-    using InstructionShape                  = cutlass::gemm::GemmShape<16, 8, 16>;
+    using InstructionShape = cutlass::gemm::GemmShape<16, 8, 16>;
 
     using Operator = typename LayoutDetails::Operator;
 };
 
-}  // namespace kernel
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace kernel
+} // namespace gemm
+} // namespace cutlass

--- a/cutlass_extensions/include/cutlass_extensions/gemm/kernel/fpA_intB_gemm.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/kernel/fpA_intB_gemm.h
@@ -44,65 +44,70 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace cutlass {
-namespace gemm {
-namespace kernel {
+namespace cutlass
+{
+namespace gemm
+{
+namespace kernel
+{
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-template<typename Mma_,                 ///! Threadblock-scoped matrix multiply-accumulate
-         typename Epilogue_,            ///! Epilogue
-         typename ThreadblockSwizzle_,  ///! Threadblock swizzling function
-         typename KernelArch,  ///! The Architecture this kernel is compiled for. Used since SIMT kernels lose top-level
-                               /// arch.
-         bool SplitKSerial     ///! If true, code supporting split-K via serial reduction is enabled.
-         >
-struct GemmFpAIntB {
+template <typename Mma_,          ///! Threadblock-scoped matrix multiply-accumulate
+    typename Epilogue_,           ///! Epilogue
+    typename ThreadblockSwizzle_, ///! Threadblock swizzling function
+    typename KernelArch, ///! The Architecture this kernel is compiled for. Used since SIMT kernels lose top-level
+                         /// arch.
+    bool SplitKSerial    ///! If true, code supporting split-K via serial reduction is enabled.
+    >
+struct GemmFpAIntB
+{
 
-    using Mma                       = Mma_;
-    using Epilogue                  = Epilogue_;
-    using EpilogueOutputOp          = typename Epilogue::OutputOp;
-    using ThreadblockSwizzle        = ThreadblockSwizzle_;
+    using Mma = Mma_;
+    using Epilogue = Epilogue_;
+    using EpilogueOutputOp = typename Epilogue::OutputOp;
+    using ThreadblockSwizzle = ThreadblockSwizzle_;
     static bool const kSplitKSerial = SplitKSerial;
 
-    using ElementA     = typename Mma::IteratorA::Element;
-    using LayoutA      = typename Mma::IteratorA::Layout;
-    using ElementB     = typename Mma::IteratorB::Element;
-    using LayoutB      = typename Mma::IteratorB::Element;
-    using ElementC     = typename Epilogue::OutputTileIterator::Element;
-    using LayoutC      = typename Mma::LayoutC;
+    using ElementA = typename Mma::IteratorA::Element;
+    using LayoutA = typename Mma::IteratorA::Layout;
+    using ElementB = typename Mma::IteratorB::Element;
+    using LayoutB = typename Mma::IteratorB::Element;
+    using ElementC = typename Epilogue::OutputTileIterator::Element;
+    using LayoutC = typename Mma::LayoutC;
     using ElementScale = ElementC;
 
     static ComplexTransform const kTransformA = Mma::kTransformA;
     static ComplexTransform const kTransformB = Mma::kTransformA;
 
     // Type definitions about the mainloop.
-    using Operator         = typename Mma::Operator;
-    using OperatorClass    = typename Mma::Operator::OperatorClass;
+    using Operator = typename Mma::Operator;
+    using OperatorClass = typename Mma::Operator::OperatorClass;
     using ThreadblockShape = typename Mma::Shape;
-    using WarpShape        = typename Mma::Operator::Shape;
+    using WarpShape = typename Mma::Operator::Shape;
     using InstructionShape = typename Mma::Policy::Operator::InstructionShape;
-    using ArchTag          = typename Mma::ArchTag;
+    using ArchTag = typename Mma::ArchTag;
 
-    static int const kStages     = Mma::kStages;
+    static int const kStages = Mma::kStages;
     static int const kAlignmentA = Mma::IteratorA::AccessType::kElements;
     static int const kAlignmentB = Mma::IteratorB::AccessType::kElements;
     static int const kAlignmentC = Epilogue::OutputTileIterator::kElementsPerAccess;
 
     /// Warp count (concept: GemmShape)
-    using WarpCount               = typename Mma::WarpCount;
+    using WarpCount = typename Mma::WarpCount;
     static int const kThreadCount = 32 * WarpCount::kCount;
 
     static constexpr int kInterleave = Mma::IteratorB::Shape::kRow / Mma::Shape::kK;
 
     /// Parameters structure
-    struct Arguments {
+    struct Arguments
+    {
         GemmUniversalMode mode = GemmUniversalMode::kGemm;
 
-        cutlass::gemm::GemmCoord                         problem_size;
-        typename Mma::IteratorA::TensorRef               ref_A;
-        typename Mma::IteratorB::TensorRef               ref_B;
-        typename Mma::IteratorScale::TensorRef           ref_scale;
+        cutlass::gemm::GemmCoord problem_size;
+        typename Mma::IteratorA::TensorRef ref_A;
+        typename Mma::IteratorB::TensorRef ref_B;
+        typename Mma::IteratorScale::TensorRef ref_scale;
         typename Epilogue::OutputTileIterator::TensorRef ref_C;
         typename Epilogue::OutputTileIterator::TensorRef ref_D;
 
@@ -127,50 +132,47 @@ struct GemmFpAIntB {
         Arguments() {}
 
         CUTLASS_HOST_DEVICE
-        Arguments(cutlass::gemm::GemmCoord const&                  problem_size,
-                  typename Mma::IteratorA::TensorRef               ref_A,
-                  typename Mma::IteratorB::TensorRef               ref_B,
-                  typename Mma::IteratorScale::TensorRef           ref_scale,
-                  typename Epilogue::OutputTileIterator::TensorRef ref_C,
-                  typename Epilogue::OutputTileIterator::TensorRef ref_D,
-                  int                                              serial_split_k_factor,
-                  typename EpilogueOutputOp::Params                output_op = typename EpilogueOutputOp::Params(),
-                  int const*                                       gather_A_indices  = nullptr,
-                  int const*                                       gather_B_indices  = nullptr,
-                  int const*                                       scatter_D_indices = nullptr):
-            problem_size(problem_size),
-            ref_A(ref_A),
-            ref_B(ref_B),
-            ref_scale(ref_scale),
-            ref_C(ref_C),
-            ref_D(ref_D),
-            batch_count(serial_split_k_factor),
-            output_op(output_op),
-            gather_A_indices(gather_A_indices),
-            gather_B_indices(gather_B_indices),
-            scatter_D_indices(scatter_D_indices)
+        Arguments(cutlass::gemm::GemmCoord const& problem_size, typename Mma::IteratorA::TensorRef ref_A,
+            typename Mma::IteratorB::TensorRef ref_B, typename Mma::IteratorScale::TensorRef ref_scale,
+            typename Epilogue::OutputTileIterator::TensorRef ref_C,
+            typename Epilogue::OutputTileIterator::TensorRef ref_D, int serial_split_k_factor,
+            typename EpilogueOutputOp::Params output_op = typename EpilogueOutputOp::Params(),
+            int const* gather_A_indices = nullptr, int const* gather_B_indices = nullptr,
+            int const* scatter_D_indices = nullptr)
+            : problem_size(problem_size)
+            , ref_A(ref_A)
+            , ref_B(ref_B)
+            , ref_scale(ref_scale)
+            , ref_C(ref_C)
+            , ref_D(ref_D)
+            , batch_count(serial_split_k_factor)
+            , output_op(output_op)
+            , gather_A_indices(gather_A_indices)
+            , gather_B_indices(gather_B_indices)
+            , scatter_D_indices(scatter_D_indices)
         {
         }
     };
 
     /// Parameters structure
-    struct Params {
-        cutlass::gemm::GemmCoord                         problem_size;
-        cutlass::gemm::GemmCoord                         grid_tiled_shape;
-        int                                              swizzle_log_tile;
-        typename Mma::IteratorA::Params                  params_A;
-        typename Mma::IteratorA::TensorRef               ref_A;
-        typename Mma::IteratorB::Params                  params_B;
-        typename Mma::IteratorB::TensorRef               ref_B;
-        typename Mma::IteratorScale::Params              params_scale;
-        typename Mma::IteratorScale::TensorRef           ref_scale;
-        typename Epilogue::OutputTileIterator::Params    params_C;
+    struct Params
+    {
+        cutlass::gemm::GemmCoord problem_size;
+        cutlass::gemm::GemmCoord grid_tiled_shape;
+        int swizzle_log_tile;
+        typename Mma::IteratorA::Params params_A;
+        typename Mma::IteratorA::TensorRef ref_A;
+        typename Mma::IteratorB::Params params_B;
+        typename Mma::IteratorB::TensorRef ref_B;
+        typename Mma::IteratorScale::Params params_scale;
+        typename Mma::IteratorScale::TensorRef ref_scale;
+        typename Epilogue::OutputTileIterator::Params params_C;
         typename Epilogue::OutputTileIterator::TensorRef ref_C;
-        typename Epilogue::OutputTileIterator::Params    params_D;
+        typename Epilogue::OutputTileIterator::Params params_D;
         typename Epilogue::OutputTileIterator::TensorRef ref_D;
-        typename EpilogueOutputOp::Params                output_op;
-        int*                                             semaphore;
-        int                                              gemm_k_size;
+        typename EpilogueOutputOp::Params output_op;
+        int* semaphore;
+        int gemm_k_size;
         // For gather+scatter operations
         int const* gather_A_indices;
         int const* gather_B_indices;
@@ -181,39 +183,43 @@ struct GemmFpAIntB {
         //
 
         CUTLASS_HOST_DEVICE
-        Params(): swizzle_log_tile(0), semaphore(0), gemm_k_size(0) {}
+        Params()
+            : swizzle_log_tile(0)
+            , semaphore(0)
+            , gemm_k_size(0)
+        {
+        }
 
         CUTLASS_HOST_DEVICE
-        Params(Arguments const&                args,
-               cutlass::gemm::GemmCoord const& grid_tiled_shape,
-               const int                       gemm_k_size,
-               void*                           workspace = nullptr):
-            problem_size(args.problem_size),
-            grid_tiled_shape(grid_tiled_shape),
-            swizzle_log_tile(ThreadblockSwizzle().get_log_tile(grid_tiled_shape)),
-            params_A(args.ref_A.layout()),
-            ref_A(args.ref_A),
-            params_B(args.ref_B.layout()),
-            ref_B(args.ref_B),
-            params_scale(args.ref_scale.layout()),
-            ref_scale(args.ref_scale),
-            params_C(args.ref_C.layout()),
-            ref_C(args.ref_C),
-            params_D(args.ref_D.layout()),
-            ref_D(args.ref_D),
-            output_op(args.output_op),
-            semaphore(static_cast<int*>(workspace)),
-            gemm_k_size(gemm_k_size),
-            gather_A_indices(args.gather_A_indices),
-            gather_B_indices(args.gather_B_indices),
-            scatter_D_indices(args.scatter_D_indices)
+        Params(Arguments const& args, cutlass::gemm::GemmCoord const& grid_tiled_shape, const int gemm_k_size,
+            void* workspace = nullptr)
+            : problem_size(args.problem_size)
+            , grid_tiled_shape(grid_tiled_shape)
+            , swizzle_log_tile(ThreadblockSwizzle().get_log_tile(grid_tiled_shape))
+            , params_A(args.ref_A.layout())
+            , ref_A(args.ref_A)
+            , params_B(args.ref_B.layout())
+            , ref_B(args.ref_B)
+            , params_scale(args.ref_scale.layout())
+            , ref_scale(args.ref_scale)
+            , params_C(args.ref_C.layout())
+            , ref_C(args.ref_C)
+            , params_D(args.ref_D.layout())
+            , ref_D(args.ref_D)
+            , output_op(args.output_op)
+            , semaphore(static_cast<int*>(workspace))
+            , gemm_k_size(gemm_k_size)
+            , gather_A_indices(args.gather_A_indices)
+            , gather_B_indices(args.gather_B_indices)
+            , scatter_D_indices(args.scatter_D_indices)
         {
         }
     };
 
     /// Shared memory storage structure
-    union SharedStorage {
-        typename Mma::SharedStorage      main_loop;
+    union SharedStorage
+    {
+        typename Mma::SharedStorage main_loop;
         typename Epilogue::SharedStorage epilogue;
     };
 
@@ -229,46 +235,49 @@ struct GemmFpAIntB {
     static Status can_implement(Arguments const& args)
     {
 
-        static int const kAlignmentA =
-            (platform::is_same<typename Mma::IteratorA::Layout, layout::ColumnMajorInterleaved<32>>::value) ?
-                32 :
-            (platform::is_same<typename Mma::IteratorA::Layout, layout::ColumnMajorInterleaved<64>>::value) ?
-                64 :
-                Mma::IteratorA::AccessType::kElements;
-        static int const kAlignmentB =
-            (platform::is_same<typename Mma::IteratorB::Layout, layout::RowMajorInterleaved<32>>::value) ?
-                32 :
-            (platform::is_same<typename Mma::IteratorB::Layout, layout::RowMajorInterleaved<64>>::value) ?
-                64 :
-                Mma::IteratorB::AccessType::kElements;
+        static int const kAlignmentA
+            = (platform::is_same<typename Mma::IteratorA::Layout, layout::ColumnMajorInterleaved<32>>::value) ? 32
+            : (platform::is_same<typename Mma::IteratorA::Layout, layout::ColumnMajorInterleaved<64>>::value)
+            ? 64
+            : Mma::IteratorA::AccessType::kElements;
+        static int const kAlignmentB
+            = (platform::is_same<typename Mma::IteratorB::Layout, layout::RowMajorInterleaved<32>>::value) ? 32
+            : (platform::is_same<typename Mma::IteratorB::Layout, layout::RowMajorInterleaved<64>>::value)
+            ? 64
+            : Mma::IteratorB::AccessType::kElements;
 
         static int const kAlignmentScale = Mma::IteratorScale::AccessType::kElements;
 
         static int const kAlignmentC = (platform::is_same<typename Epilogue::OutputTileIterator::Layout,
-                                                          layout::ColumnMajorInterleaved<32>>::value) ?
-                                           32 :
-                                       (platform::is_same<typename Epilogue::OutputTileIterator::Layout,
-                                                          layout::ColumnMajorInterleaved<64>>::value) ?
-                                           64 :
-                                           Epilogue::OutputTileIterator::kElementsPerAccess;
+                                           layout::ColumnMajorInterleaved<32>>::value)
+            ? 32
+            : (platform::is_same<typename Epilogue::OutputTileIterator::Layout,
+                  layout::ColumnMajorInterleaved<64>>::value)
+            ? 64
+            : Epilogue::OutputTileIterator::kElementsPerAccess;
 
-        if (!TensorRef_aligned(args.ref_A, kAlignmentA)) {
+        if (!TensorRef_aligned(args.ref_A, kAlignmentA))
+        {
             return Status::kErrorMisalignedOperand;
         }
 
-        if (!TensorRef_aligned(args.ref_B, kAlignmentB)) {
+        if (!TensorRef_aligned(args.ref_B, kAlignmentB))
+        {
             return Status::kErrorMisalignedOperand;
         }
 
-        if (!TensorRef_aligned(args.ref_scale, kAlignmentScale)) {
+        if (!TensorRef_aligned(args.ref_scale, kAlignmentScale))
+        {
             return Status::kErrorMisalignedOperand;
         }
 
-        if (!TensorRef_aligned(args.ref_C, kAlignmentC)) {
+        if (!TensorRef_aligned(args.ref_C, kAlignmentC))
+        {
             return Status::kErrorMisalignedOperand;
         }
 
-        if (!TensorRef_aligned(args.ref_D, kAlignmentC)) {
+        if (!TensorRef_aligned(args.ref_D, kAlignmentC))
+        {
             return Status::kErrorMisalignedOperand;
         }
 
@@ -284,8 +293,9 @@ struct GemmFpAIntB {
     // The dummy template parameter is not used and exists so that we can compile this code using
     // a standard earlier than C++17. Prior to C++17, fully specialized templates HAD to exists in
     // a namespace
-    template<bool B, typename dummy = void>
-    struct KernelRunner {
+    template <bool B, typename dummy = void>
+    struct KernelRunner
+    {
         CUTLASS_DEVICE
         static void run_kernel(Params const& params, SharedStorage& shared_storage)
         {
@@ -293,25 +303,27 @@ struct GemmFpAIntB {
         }
     };
 
-    template<typename dummy>
-    struct KernelRunner<true, dummy> {
+    template <typename dummy>
+    struct KernelRunner<true, dummy>
+    {
         CUTLASS_DEVICE
         static void run_kernel(Params const& params, SharedStorage& shared_storage)
         {
             using LayoutB = typename Mma::IteratorB::Layout;
             static_assert(platform::is_same<LayoutB, layout::RowMajor>::value && kInterleave == 1
-                              || platform::is_same<LayoutB, layout::ColumnMajor>::value && kInterleave >= 1,
-                          "B must be row major/col major OR col major interleaved.");
+                    || platform::is_same<LayoutB, layout::ColumnMajor>::value && kInterleave >= 1,
+                "B must be row major/col major OR col major interleaved.");
 
             // Compute threadblock location
             ThreadblockSwizzle threadblock_swizzle;
 
-            cutlass::gemm::GemmCoord threadblock_tile_offset =
-                threadblock_swizzle.get_tile_offset(params.swizzle_log_tile);
+            cutlass::gemm::GemmCoord threadblock_tile_offset
+                = threadblock_swizzle.get_tile_offset(params.swizzle_log_tile);
 
             // Early exit if CTA is out of range
             if (params.grid_tiled_shape.m() <= threadblock_tile_offset.m()
-                || params.grid_tiled_shape.n() <= threadblock_tile_offset.n()) {
+                || params.grid_tiled_shape.n() <= threadblock_tile_offset.n())
+            {
 
                 return;
             }
@@ -323,7 +335,7 @@ struct GemmFpAIntB {
             };
 
             cutlass::MatrixCoord tb_offset_B{threadblock_tile_offset.k() * params.gemm_k_size * kInterleave,
-                                             threadblock_tile_offset.n() * Mma::Shape::kN / kInterleave};
+                threadblock_tile_offset.n() * Mma::Shape::kN / kInterleave};
 
             cutlass::MatrixCoord tb_offset_scale{0, threadblock_tile_offset.n() * Mma::Shape::kN};
 
@@ -337,25 +349,15 @@ struct GemmFpAIntB {
             int thread_idx = threadIdx.x;
 
             // Construct iterators to A and B operands
-            typename Mma::IteratorA iterator_A(params.params_A,
-                                               params.ref_A.data(),
-                                               {params.problem_size.m(), problem_size_k},
-                                               thread_idx,
-                                               tb_offset_A,
-                                               params.gather_A_indices);
+            typename Mma::IteratorA iterator_A(params.params_A, params.ref_A.data(),
+                {params.problem_size.m(), problem_size_k}, thread_idx, tb_offset_A, params.gather_A_indices);
 
-            typename Mma::IteratorB iterator_B(params.params_B,
-                                               params.ref_B.data(),
-                                               {problem_size_k * kInterleave, params.problem_size.n() / kInterleave},
-                                               thread_idx,
-                                               tb_offset_B,
-                                               params.gather_B_indices);
+            typename Mma::IteratorB iterator_B(params.params_B, params.ref_B.data(),
+                {problem_size_k * kInterleave, params.problem_size.n() / kInterleave}, thread_idx, tb_offset_B,
+                params.gather_B_indices);
 
-            typename Mma::IteratorScale iterator_scale(params.params_scale,
-                                                       params.ref_scale.data(),
-                                                       {1, params.problem_size.n()},
-                                                       thread_idx,
-                                                       tb_offset_scale);
+            typename Mma::IteratorScale iterator_scale(params.params_scale, params.ref_scale.data(),
+                {1, params.problem_size.n()}, thread_idx, tb_offset_scale);
 
             // Broadcast the warp_id computed by lane 0 to ensure dependent code
             // is compiled as warp-uniform.
@@ -372,7 +374,8 @@ struct GemmFpAIntB {
 
             accumulators.clear();
 
-            if (!kSplitKSerial || gemm_k_iterations > 0) {
+            if (!kSplitKSerial || gemm_k_iterations > 0)
+            {
                 // Compute threadblock-scoped matrix multiply-add
                 mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, iterator_scale, accumulators);
             }
@@ -390,8 +393,8 @@ struct GemmFpAIntB {
             threadblock_tile_offset = threadblock_swizzle.get_tile_offset(params.swizzle_log_tile);
 
             // assume identity swizzle
-            MatrixCoord threadblock_offset(threadblock_tile_offset.m() * Mma::Shape::kM,
-                                           threadblock_tile_offset.n() * Mma::Shape::kN);
+            MatrixCoord threadblock_offset(
+                threadblock_tile_offset.m() * Mma::Shape::kM, threadblock_tile_offset.n() * Mma::Shape::kN);
 
             int block_idx = threadblock_tile_offset.m() + threadblock_tile_offset.n() * params.grid_tiled_shape.m();
 
@@ -399,7 +402,8 @@ struct GemmFpAIntB {
             Semaphore semaphore(params.semaphore + block_idx, thread_idx);
 
             // If performing a reduction via split-K, fetch the initial synchronization
-            if (kSplitKSerial && params.grid_tiled_shape.k() > 1) {
+            if (kSplitKSerial && params.grid_tiled_shape.k() > 1)
+            {
 
                 // Fetch the synchronization lock initially but do not block.
                 semaphore.fetch();
@@ -409,28 +413,22 @@ struct GemmFpAIntB {
             }
 
             // Tile iterator loading from source tensor.
-            typename Epilogue::OutputTileIterator iterator_C(params.params_C,
-                                                             params.ref_C.data(),
-                                                             params.problem_size.mn(),
-                                                             thread_idx,
-                                                             threadblock_offset,
-                                                             params.scatter_D_indices);
+            typename Epilogue::OutputTileIterator iterator_C(params.params_C, params.ref_C.data(),
+                params.problem_size.mn(), thread_idx, threadblock_offset, params.scatter_D_indices);
 
             // Tile iterator writing to destination tensor.
-            typename Epilogue::OutputTileIterator iterator_D(params.params_D,
-                                                             params.ref_D.data(),
-                                                             params.problem_size.mn(),
-                                                             thread_idx,
-                                                             threadblock_offset,
-                                                             params.scatter_D_indices);
+            typename Epilogue::OutputTileIterator iterator_D(params.params_D, params.ref_D.data(),
+                params.problem_size.mn(), thread_idx, threadblock_offset, params.scatter_D_indices);
 
             Epilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx, lane_idx);
 
             // Wait on the semaphore - this latency may have been covered by iterator construction
-            if (kSplitKSerial && params.grid_tiled_shape.k() > 1) {
+            if (kSplitKSerial && params.grid_tiled_shape.k() > 1)
+            {
 
                 // For subsequent threadblocks, the source matrix is held in the 'D' tensor.
-                if (threadblock_tile_offset.k()) {
+                if (threadblock_tile_offset.k())
+                {
                     iterator_C = iterator_D;
                 }
 
@@ -444,15 +442,18 @@ struct GemmFpAIntB {
             // Release the semaphore
             //
 
-            if (kSplitKSerial && params.grid_tiled_shape.k() > 1) {
+            if (kSplitKSerial && params.grid_tiled_shape.k() > 1)
+            {
 
                 int lock = 0;
-                if (params.grid_tiled_shape.k() == threadblock_tile_offset.k() + 1) {
+                if (params.grid_tiled_shape.k() == threadblock_tile_offset.k() + 1)
+                {
 
                     // The final threadblock resets the semaphore for subsequent grids.
                     lock = 0;
                 }
-                else {
+                else
+                {
                     // Otherwise, the semaphore is incremented
                     lock = threadblock_tile_offset.k() + 1;
                 }
@@ -487,6 +488,6 @@ struct GemmFpAIntB {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-}  // namespace kernel
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace kernel
+} // namespace gemm
+} // namespace cutlass

--- a/cutlass_extensions/include/cutlass_extensions/gemm/kernel/fpA_intB_gemm_with_broadcast.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/kernel/fpA_intB_gemm_with_broadcast.h
@@ -46,398 +46,414 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace cutlass {
-namespace gemm {
-namespace kernel {
+namespace cutlass
+{
+namespace gemm
+{
+namespace kernel
+{
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-template <typename Mma_,      ///! Threadblock-scoped matrix multiply-accumulate
-          typename Epilogue_, ///! Epilogue
-          typename ThreadblockSwizzle_, ///! Threadblock swizzling function
-          typename KernelArch ///! The Architecture this kernel is compiled for.
-                              /// Used since SIMT kernels lose top-level arch.
-                              //////
-          >
-struct GemmFpAIntBWithBroadcast {
+template <typename Mma_,          ///! Threadblock-scoped matrix multiply-accumulate
+    typename Epilogue_,           ///! Epilogue
+    typename ThreadblockSwizzle_, ///! Threadblock swizzling function
+    typename KernelArch           ///! The Architecture this kernel is compiled for.
+                                  /// Used since SIMT kernels lose top-level arch.
+                                  //////
+    >
+struct GemmFpAIntBWithBroadcast
+{
 
-  using Mma = Mma_;
-  using Epilogue = Epilogue_;
-  using EpilogueOutputOp = typename Epilogue::OutputOp;
-  using ThreadblockSwizzle = ThreadblockSwizzle_;
+    using Mma = Mma_;
+    using Epilogue = Epilogue_;
+    using EpilogueOutputOp = typename Epilogue::OutputOp;
+    using ThreadblockSwizzle = ThreadblockSwizzle_;
 
-  using ElementA = typename Mma::IteratorA::Element;
-  using LayoutA = typename Mma::IteratorA::Layout;
-  using ElementB = typename Mma::IteratorB::Element;
-  using LayoutB = typename Mma::IteratorB::Element;
-  using ElementC = typename Epilogue::OutputTileIterator::Element;
-  using LayoutC = typename Mma::LayoutC;
-  using ElementScale = ElementC;
+    using ElementA = typename Mma::IteratorA::Element;
+    using LayoutA = typename Mma::IteratorA::Layout;
+    using ElementB = typename Mma::IteratorB::Element;
+    using LayoutB = typename Mma::IteratorB::Element;
+    using ElementC = typename Epilogue::OutputTileIterator::Element;
+    using LayoutC = typename Mma::LayoutC;
+    using ElementScale = ElementC;
 
-  static ComplexTransform const kTransformA = Mma::kTransformA;
-  static ComplexTransform const kTransformB = Mma::kTransformA;
+    static ComplexTransform const kTransformA = Mma::kTransformA;
+    static ComplexTransform const kTransformB = Mma::kTransformA;
 
-  // Type definitions about the mainloop.
-  using Operator = typename Mma::Operator;
-  using OperatorClass = typename Mma::Operator::OperatorClass;
-  using ThreadblockShape = typename Mma::Shape;
-  using WarpShape = typename Mma::Operator::Shape;
-  using InstructionShape = typename Mma::Policy::Operator::InstructionShape;
-  using ArchTag = typename Mma::ArchTag;
+    // Type definitions about the mainloop.
+    using Operator = typename Mma::Operator;
+    using OperatorClass = typename Mma::Operator::OperatorClass;
+    using ThreadblockShape = typename Mma::Shape;
+    using WarpShape = typename Mma::Operator::Shape;
+    using InstructionShape = typename Mma::Policy::Operator::InstructionShape;
+    using ArchTag = typename Mma::ArchTag;
 
-  static int const kStages = Mma::kStages;
-  static int const kAlignmentA = Mma::IteratorA::AccessType::kElements;
-  static int const kAlignmentB = Mma::IteratorB::AccessType::kElements;
-  static int const kAlignmentC =
-      Epilogue::OutputTileIterator::kElementsPerAccess;
+    static int const kStages = Mma::kStages;
+    static int const kAlignmentA = Mma::IteratorA::AccessType::kElements;
+    static int const kAlignmentB = Mma::IteratorB::AccessType::kElements;
+    static int const kAlignmentC = Epilogue::OutputTileIterator::kElementsPerAccess;
 
-  /// Warp count (concept: GemmShape)
-  using WarpCount = typename Mma::WarpCount;
-  static int const kThreadCount = 32 * WarpCount::kCount;
+    /// Warp count (concept: GemmShape)
+    using WarpCount = typename Mma::WarpCount;
+    static int const kThreadCount = 32 * WarpCount::kCount;
 
-  static constexpr int kInterleave =
-      Mma::IteratorB::Shape::kRow / Mma::Shape::kK;
+    static constexpr int kInterleave = Mma::IteratorB::Shape::kRow / Mma::Shape::kK;
 
-  /// Parameters structure
-  struct Arguments {
-    GemmUniversalMode mode = GemmUniversalMode::kGemm;
+    /// Parameters structure
+    struct Arguments
+    {
+        GemmUniversalMode mode = GemmUniversalMode::kGemm;
 
-    cutlass::gemm::GemmCoord problem_size;
-    int batch_count;
-    typename EpilogueOutputOp::Params epilogue;
+        cutlass::gemm::GemmCoord problem_size;
+        int batch_count;
+        typename EpilogueOutputOp::Params epilogue;
 
-    void const *ptr_A;
-    void const *ptr_B;
-    void const *ptr_scales;
-    void const *ptr_C;
-    void *ptr_D;
+        void const* ptr_A;
+        void const* ptr_B;
+        void const* ptr_scales;
+        void const* ptr_C;
+        void* ptr_D;
 
-    void const *ptr_Vector;
-    void const *ptr_Tensor;
+        void const* ptr_Vector;
+        void const* ptr_Tensor;
 
-    int64_t batch_stride_A;
-    int64_t batch_stride_B;
-    int64_t batch_stride_C;
-    int64_t batch_stride_D;
-    int64_t batch_stride_Vector;
-    int64_t batch_stride_Tensor;
+        int64_t batch_stride_A;
+        int64_t batch_stride_B;
+        int64_t batch_stride_C;
+        int64_t batch_stride_D;
+        int64_t batch_stride_Vector;
+        int64_t batch_stride_Tensor;
 
-    int lda, ldb, ldc, ldd, ldr, ldt;
+        int lda, ldb, ldc, ldd, ldr, ldt;
 
-    typename EpilogueOutputOp::Params output_op;
+        typename EpilogueOutputOp::Params output_op;
 
-    // For gather+scatter operations
-    int const *gather_A_indices;
-    int const *gather_B_indices;
-    int const *scatter_D_indices;
+        // For gather+scatter operations
+        int const* gather_A_indices;
+        int const* gather_B_indices;
+        int const* scatter_D_indices;
 
-    CUTLASS_HOST_DEVICE
-    Arguments() {}
+        CUTLASS_HOST_DEVICE
+        Arguments() {}
 
-    CUTLASS_HOST_DEVICE
-    Arguments(cutlass::gemm::GemmCoord const &problem_size, int batch_count,
-              typename EpilogueOutputOp::Params epilogue, void const *ptr_A,
-              void const *ptr_B, void const *ptr_scales, void const *ptr_C,
-              void *ptr_D, const void *ptr_Vector, const void *ptr_Tensor,
-              int64_t batch_stride_A, int64_t batch_stride_B,
-              int64_t batch_stride_C, int64_t batch_stride_D,
-              int64_t batch_stride_Vector, int64_t batch_stride_Tensor,
-	      int lda, int ldb, int ldc, int ldd, int ldr, int ldt,
-              typename EpilogueOutputOp::Params output_op =
-                  typename EpilogueOutputOp::Params())
-        : problem_size(problem_size), batch_count(batch_count),
-          epilogue(epilogue), ptr_A(ptr_A), ptr_B(ptr_B),
-          ptr_scales(ptr_scales), ptr_C(ptr_C), ptr_D(ptr_D),
-          ptr_Vector(ptr_Vector), ptr_Tensor(ptr_Tensor),
-          batch_stride_A(batch_stride_A), batch_stride_B(batch_stride_B),
-          batch_stride_C(batch_stride_C), batch_stride_D(batch_stride_D),
-          batch_stride_Vector(batch_stride_Vector),
-          batch_stride_Tensor(batch_stride_Tensor), lda(lda), ldb(ldb),
-          ldc(ldc), ldd(ldd), ldr(ldr), ldt(ldt), output_op(output_op),
-          gather_A_indices(nullptr), gather_B_indices(nullptr),
-          scatter_D_indices(nullptr) {}
-  };
+        CUTLASS_HOST_DEVICE
+        Arguments(cutlass::gemm::GemmCoord const& problem_size, int batch_count,
+            typename EpilogueOutputOp::Params epilogue, void const* ptr_A, void const* ptr_B, void const* ptr_scales,
+            void const* ptr_C, void* ptr_D, const void* ptr_Vector, const void* ptr_Tensor, int64_t batch_stride_A,
+            int64_t batch_stride_B, int64_t batch_stride_C, int64_t batch_stride_D, int64_t batch_stride_Vector,
+            int64_t batch_stride_Tensor, int lda, int ldb, int ldc, int ldd, int ldr, int ldt,
+            typename EpilogueOutputOp::Params output_op = typename EpilogueOutputOp::Params())
+            : problem_size(problem_size)
+            , batch_count(batch_count)
+            , epilogue(epilogue)
+            , ptr_A(ptr_A)
+            , ptr_B(ptr_B)
+            , ptr_scales(ptr_scales)
+            , ptr_C(ptr_C)
+            , ptr_D(ptr_D)
+            , ptr_Vector(ptr_Vector)
+            , ptr_Tensor(ptr_Tensor)
+            , batch_stride_A(batch_stride_A)
+            , batch_stride_B(batch_stride_B)
+            , batch_stride_C(batch_stride_C)
+            , batch_stride_D(batch_stride_D)
+            , batch_stride_Vector(batch_stride_Vector)
+            , batch_stride_Tensor(batch_stride_Tensor)
+            , lda(lda)
+            , ldb(ldb)
+            , ldc(ldc)
+            , ldd(ldd)
+            , ldr(ldr)
+            , ldt(ldt)
+            , output_op(output_op)
+            , gather_A_indices(nullptr)
+            , gather_B_indices(nullptr)
+            , scatter_D_indices(nullptr)
+        {
+        }
+    };
 
-  /// Parameters structure
-  struct Params {
-    cutlass::gemm::GemmCoord problem_size;
-    cutlass::gemm::GemmCoord grid_tiled_shape;
-    int swizzle_log_tile;
+    /// Parameters structure
+    struct Params
+    {
+        cutlass::gemm::GemmCoord problem_size;
+        cutlass::gemm::GemmCoord grid_tiled_shape;
+        int swizzle_log_tile;
 
-    typename Mma::IteratorA::Params params_A;
-    typename Mma::IteratorB::Params params_B;
-    typename Mma::IteratorScale::Params params_scale;
-    typename Epilogue::OutputTileIterator::Params params_C;
-    typename Epilogue::OutputTileIterator::Params params_D;
-    typename Epilogue::TensorTileIterator::Params params_Tensor;
+        typename Mma::IteratorA::Params params_A;
+        typename Mma::IteratorB::Params params_B;
+        typename Mma::IteratorScale::Params params_scale;
+        typename Epilogue::OutputTileIterator::Params params_C;
+        typename Epilogue::OutputTileIterator::Params params_D;
+        typename Epilogue::TensorTileIterator::Params params_Tensor;
 
-    typename EpilogueOutputOp::Params output_op;
+        typename EpilogueOutputOp::Params output_op;
 
-    // GemmUniversalMode mode; todo
-    int batch_count;
-    int gemm_k_size;
-    void *ptr_A;
-    void *ptr_B;
-    void *ptr_C;
-    void *ptr_scales;
-    void *ptr_D;
+        // GemmUniversalMode mode; todo
+        int batch_count;
+        int gemm_k_size;
+        void* ptr_A;
+        void* ptr_B;
+        void* ptr_C;
+        void* ptr_scales;
+        void* ptr_D;
 
-    void *ptr_Vector;
-    typename LayoutC::Stride::Index ldr;
+        void* ptr_Vector;
+        typename LayoutC::Stride::Index ldr;
 
-    void *ptr_Tensor;
+        void* ptr_Tensor;
 
-    int64_t batch_stride_A;
-    int64_t batch_stride_B;
-    int64_t batch_stride_C;
-    int64_t batch_stride_D;
-    int64_t batch_stride_Vector;
-    int64_t batch_stride_Tensor;
+        int64_t batch_stride_A;
+        int64_t batch_stride_B;
+        int64_t batch_stride_C;
+        int64_t batch_stride_D;
+        int64_t batch_stride_Vector;
+        int64_t batch_stride_Tensor;
 
-    // For gather+scatter operations
-    int const *gather_A_indices;
-    int const *gather_B_indices;
-    int const *scatter_D_indices;
+        // For gather+scatter operations
+        int const* gather_A_indices;
+        int const* gather_B_indices;
+        int const* scatter_D_indices;
+
+        //
+        // Methods
+        //
+
+        CUTLASS_HOST_DEVICE
+        Params()
+            : swizzle_log_tile(0)
+            , gemm_k_size(0)
+        {
+        }
+
+        CUTLASS_HOST_DEVICE
+        Params(Arguments const& args, cutlass::gemm::GemmCoord const& grid_tiled_shape, const int gemm_k_size,
+            void* workspace = nullptr)
+            : problem_size(args.problem_size)
+            , grid_tiled_shape(grid_tiled_shape)
+            , swizzle_log_tile(ThreadblockSwizzle().get_log_tile(grid_tiled_shape))
+            , params_A(args.lda)
+            , params_B(args.ldb)
+            , params_C(args.ldc)
+            , params_D(args.ldd)
+            , params_Tensor(args.ldt)
+            , output_op(args.epilogue)
+            , batch_count(args.batch_count)
+            , gemm_k_size(gemm_k_size)
+            , ptr_A(const_cast<void*>(args.ptr_A))
+            , ptr_B(const_cast<void*>(args.ptr_B))
+            , ptr_scales(const_cast<void*>(args.ptr_scales))
+            , ptr_C(const_cast<void*>(args.ptr_C))
+            , ptr_D(args.ptr_D)
+            , ptr_Vector(const_cast<void*>(args.ptr_Vector))
+            , ldr(args.ldr)
+            , ptr_Tensor(const_cast<void*>(args.ptr_Tensor))
+            , batch_stride_A(args.batch_stride_A)
+            , batch_stride_B(args.batch_stride_B)
+            , batch_stride_C(args.batch_stride_C)
+            , batch_stride_D(args.batch_stride_D)
+            , batch_stride_Vector(args.batch_stride_Vector)
+            , batch_stride_Tensor(args.batch_stride_Tensor)
+            , gather_A_indices(args.gather_A_indices)
+            , gather_B_indices(args.gather_B_indices)
+            , scatter_D_indices(args.scatter_D_indices)
+        {
+        }
+    };
+
+    /// Shared memory storage structure
+    union SharedStorage
+    {
+        typename Mma::SharedStorage main_loop;
+        typename Epilogue::SharedStorage epilogue;
+    };
 
     //
     // Methods
     //
 
     CUTLASS_HOST_DEVICE
-    Params() : swizzle_log_tile(0), gemm_k_size(0) {}
+    GemmFpAIntBWithBroadcast() {}
 
     CUTLASS_HOST_DEVICE
-    Params(Arguments const &args,
-           cutlass::gemm::GemmCoord const &grid_tiled_shape,
-           const int gemm_k_size, void *workspace = nullptr)
-        : problem_size(args.problem_size), grid_tiled_shape(grid_tiled_shape),
-          swizzle_log_tile(ThreadblockSwizzle().get_log_tile(grid_tiled_shape)),
-          params_A(args.lda), params_B(args.ldb), params_C(args.ldc),
-          params_D(args.ldd), params_Tensor(args.ldt), output_op(args.epilogue),
-          batch_count(args.batch_count), gemm_k_size(gemm_k_size),
-          ptr_A(const_cast<void *>(args.ptr_A)),
-          ptr_B(const_cast<void *>(args.ptr_B)),
-          ptr_scales(const_cast<void *>(args.ptr_scales)),
-          ptr_C(const_cast<void *>(args.ptr_C)), ptr_D(args.ptr_D),
-          ptr_Vector(const_cast<void *>(args.ptr_Vector)), ldr(args.ldr),
-          ptr_Tensor(const_cast<void *>(args.ptr_Tensor)), batch_stride_A(args.batch_stride_A),
-          batch_stride_B(args.batch_stride_B),
-          batch_stride_C(args.batch_stride_C),
-          batch_stride_D(args.batch_stride_D),
-          batch_stride_Vector(args.batch_stride_Vector),
-          batch_stride_Tensor(args.batch_stride_Tensor),
-          gather_A_indices(args.gather_A_indices),
-          gather_B_indices(args.gather_B_indices),
-          scatter_D_indices(args.scatter_D_indices) {}
-  };
-
-  /// Shared memory storage structure
-  union SharedStorage {
-    typename Mma::SharedStorage main_loop;
-    typename Epilogue::SharedStorage epilogue;
-  };
-
-  //
-  // Methods
-  //
-
-  CUTLASS_HOST_DEVICE
-  GemmFpAIntBWithBroadcast() {}
-
-  CUTLASS_HOST_DEVICE
-  static Status can_implement(Arguments const &args) {
-    // todo
-    return Status::kSuccess;
-  }
-
-  static size_t
-  get_extra_workspace_size(Arguments const &args,
-                           cutlass::gemm::GemmCoord const &grid_tiled_shape) {
-
-    return 0;
-  }
-
-  // The dummy template parameter is not used and exists so that we can compile
-  // this code using a standard earlier than C++17. Prior to C++17, fully
-  // specialized templates HAD to exists in a namespace
-  template <bool B, typename dummy = void> struct KernelRunner {
-    CUTLASS_DEVICE
-    static void run_kernel(Params const &params,
-                           SharedStorage &shared_storage) {
-      CUTLASS_NOT_IMPLEMENTED();
+    static Status can_implement(Arguments const& args)
+    {
+        // todo
+        return Status::kSuccess;
     }
-  };
 
-  template <typename dummy> struct KernelRunner<true, dummy> {
-    CUTLASS_DEVICE
-    static void run_kernel(Params const &params,
-                           SharedStorage &shared_storage) {
-      using LayoutB = typename Mma::IteratorB::Layout;
-      static_assert(
-          platform::is_same<LayoutB, layout::RowMajor>::value &&
-                  kInterleave == 1 ||
-              platform::is_same<LayoutB, layout::ColumnMajor>::value &&
-                  kInterleave >= 1,
-          "B must be row major/col major OR col major  interleaved.");
+    static size_t get_extra_workspace_size(Arguments const& args, cutlass::gemm::GemmCoord const& grid_tiled_shape)
+    {
 
-      // Compute threadblock location
-      ThreadblockSwizzle threadblock_swizzle;
-
-      cutlass::gemm::GemmCoord threadblock_tile_offset =
-          threadblock_swizzle.get_tile_offset(params.swizzle_log_tile);
-
-      // Early exit if CTA is out of range
-      if (params.grid_tiled_shape.m() <= threadblock_tile_offset.m() ||
-          params.grid_tiled_shape.n() <= threadblock_tile_offset.n()) {
-
-        return;
-      }
-
-      // Compute initial location in logical coordinates
-      cutlass::MatrixCoord tb_offset_A{
-          threadblock_tile_offset.m() * Mma::Shape::kM,
-          threadblock_tile_offset.k() * params.gemm_k_size,
-      };
-
-      cutlass::MatrixCoord tb_offset_B{
-          threadblock_tile_offset.k() * params.gemm_k_size * kInterleave,
-          threadblock_tile_offset.n() * Mma::Shape::kN / kInterleave};
-
-      cutlass::MatrixCoord tb_offset_scale{0, threadblock_tile_offset.n() *
-                                                  Mma::Shape::kN};
-
-      // Problem size is a function of threadblock index in the K dimension
-      int problem_size_k =
-          min(params.problem_size.k(),
-              (threadblock_tile_offset.k() + 1) * params.gemm_k_size);
-
-      // Compute threadblock-scoped matrix multiply-add
-      int gemm_k_iterations =
-          (problem_size_k - tb_offset_A.column() + Mma::Shape::kK - 1) /
-          Mma::Shape::kK;
-
-      // Compute position within threadblock
-      int thread_idx = threadIdx.x;
-
-      // Construct iterators to A and B operands
-      typename Mma::IteratorA iterator_A(
-          params.params_A, static_cast<ElementA *>(params.ptr_A),
-          {params.problem_size.m(), problem_size_k}, thread_idx, tb_offset_A,
-          params.gather_A_indices);
-
-      typename Mma::IteratorB iterator_B(
-          params.params_B, static_cast<ElementB *>(params.ptr_B),
-          {problem_size_k * kInterleave, params.problem_size.n() / kInterleave},
-          thread_idx, tb_offset_B, params.gather_B_indices);
-
-      typename Mma::IteratorScale iterator_scale(
-          params.params_scale, static_cast<ElementScale *>(params.ptr_scales),
-          {1, params.problem_size.n()}, thread_idx, tb_offset_scale);
-
-      // Broadcast the warp_id computed by lane 0 to ensure dependent code is
-      // compiled as warp-uniform.
-      int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
-      int lane_idx = threadIdx.x % 32;
-
-      //
-      // Main loop
-      //
-      // Construct thread-scoped matrix multiply
-      Mma mma(shared_storage.main_loop, thread_idx, warp_idx, lane_idx);
-
-      typename Mma::FragmentC accumulators;
-
-      accumulators.clear();
-
-      if (gemm_k_iterations > 0) {
-        // Compute threadblock-scoped matrix multiply-add
-        mma(gemm_k_iterations, accumulators, iterator_A, iterator_B,
-            iterator_scale, accumulators);
-      }
-
-      //
-      // Epilogue
-      //
-
-      EpilogueOutputOp output_op(params.output_op);
-
-      //
-      // Masked tile iterators constructed from members
-      //
-
-      threadblock_tile_offset =
-          threadblock_swizzle.get_tile_offset(params.swizzle_log_tile);
-
-      // assume identity swizzle
-      MatrixCoord threadblock_offset(
-          threadblock_tile_offset.m() * Mma::Shape::kM,
-          threadblock_tile_offset.n() * Mma::Shape::kN);
-
-      int block_idx = threadblock_tile_offset.m() +
-                      threadblock_tile_offset.n() * params.grid_tiled_shape.m();
-
-      ElementC *ptr_C = static_cast<ElementC *>(params.ptr_C);
-      ElementC *ptr_D = static_cast<ElementC *>(params.ptr_D);
-
-      // Tile iterator loading from source tensor.
-      typename Epilogue::OutputTileIterator iterator_C(
-          params.params_C, ptr_C, params.problem_size.mn(),
-          thread_idx, threadblock_offset, params.scatter_D_indices);
-
-      // Tile iterator writing to destination tensor.
-      typename Epilogue::OutputTileIterator iterator_D(
-          params.params_D, ptr_D, params.problem_size.mn(),
-          thread_idx, threadblock_offset, params.scatter_D_indices);
-
-      typename Epilogue::ElementTensor *ptr_Tensor =
-          static_cast<typename Epilogue::ElementTensor *>(params.ptr_Tensor);
-
-      // Define the reduction output pointer and move to the appropriate place
-      typename Epilogue::ElementVector *ptr_Vector =
-          static_cast<typename Epilogue::ElementVector *>(params.ptr_Vector);
-
-      typename Epilogue::TensorTileIterator tensor_iterator(
-          params.params_Tensor,
-          // Only the final block outputs Tensor
-          ptr_Tensor, params.problem_size.mn(), thread_idx, threadblock_offset);
-
-      Epilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx,
-                        lane_idx);
-
-      if (ptr_Vector) {
-        ptr_Vector += threadblock_offset.column() +
-                      threadblock_tile_offset.m() * params.ldr;
-      }
-
-      epilogue(output_op, ptr_Vector, iterator_D, accumulators, iterator_C,
-               tensor_iterator, params.problem_size.mn(), threadblock_offset);
+        return 0;
     }
-  };
 
-  /*
-      To improve compilation speed, we do not compile the device operator if the
-     CUDA_ARCH does not correspond to the ArchTag of the cutlass kernel
-     operator.
-    */
-  /// Executes one GEMM
-  CUTLASS_DEVICE
-  void operator()(Params const &params, SharedStorage &shared_storage) {
+    // The dummy template parameter is not used and exists so that we can compile
+    // this code using a standard earlier than C++17. Prior to C++17, fully
+    // specialized templates HAD to exists in a namespace
+    template <bool B, typename dummy = void>
+    struct KernelRunner
+    {
+        CUTLASS_DEVICE
+        static void run_kernel(Params const& params, SharedStorage& shared_storage)
+        {
+            CUTLASS_NOT_IMPLEMENTED();
+        }
+    };
+
+    template <typename dummy>
+    struct KernelRunner<true, dummy>
+    {
+        CUTLASS_DEVICE
+        static void run_kernel(Params const& params, SharedStorage& shared_storage)
+        {
+            using LayoutB = typename Mma::IteratorB::Layout;
+            static_assert(platform::is_same<LayoutB, layout::RowMajor>::value && kInterleave == 1
+                    || platform::is_same<LayoutB, layout::ColumnMajor>::value && kInterleave >= 1,
+                "B must be row major/col major OR col major  interleaved.");
+
+            // Compute threadblock location
+            ThreadblockSwizzle threadblock_swizzle;
+
+            cutlass::gemm::GemmCoord threadblock_tile_offset
+                = threadblock_swizzle.get_tile_offset(params.swizzle_log_tile);
+
+            // Early exit if CTA is out of range
+            if (params.grid_tiled_shape.m() <= threadblock_tile_offset.m()
+                || params.grid_tiled_shape.n() <= threadblock_tile_offset.n())
+            {
+
+                return;
+            }
+
+            // Compute initial location in logical coordinates
+            cutlass::MatrixCoord tb_offset_A{
+                threadblock_tile_offset.m() * Mma::Shape::kM,
+                threadblock_tile_offset.k() * params.gemm_k_size,
+            };
+
+            cutlass::MatrixCoord tb_offset_B{threadblock_tile_offset.k() * params.gemm_k_size * kInterleave,
+                threadblock_tile_offset.n() * Mma::Shape::kN / kInterleave};
+
+            cutlass::MatrixCoord tb_offset_scale{0, threadblock_tile_offset.n() * Mma::Shape::kN};
+
+            // Problem size is a function of threadblock index in the K dimension
+            int problem_size_k = min(params.problem_size.k(), (threadblock_tile_offset.k() + 1) * params.gemm_k_size);
+
+            // Compute threadblock-scoped matrix multiply-add
+            int gemm_k_iterations = (problem_size_k - tb_offset_A.column() + Mma::Shape::kK - 1) / Mma::Shape::kK;
+
+            // Compute position within threadblock
+            int thread_idx = threadIdx.x;
+
+            // Construct iterators to A and B operands
+            typename Mma::IteratorA iterator_A(params.params_A, static_cast<ElementA*>(params.ptr_A),
+                {params.problem_size.m(), problem_size_k}, thread_idx, tb_offset_A, params.gather_A_indices);
+
+            typename Mma::IteratorB iterator_B(params.params_B, static_cast<ElementB*>(params.ptr_B),
+                {problem_size_k * kInterleave, params.problem_size.n() / kInterleave}, thread_idx, tb_offset_B,
+                params.gather_B_indices);
+
+            typename Mma::IteratorScale iterator_scale(params.params_scale,
+                static_cast<ElementScale*>(params.ptr_scales), {1, params.problem_size.n()}, thread_idx,
+                tb_offset_scale);
+
+            // Broadcast the warp_id computed by lane 0 to ensure dependent code is
+            // compiled as warp-uniform.
+            int warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+            int lane_idx = threadIdx.x % 32;
+
+            //
+            // Main loop
+            //
+            // Construct thread-scoped matrix multiply
+            Mma mma(shared_storage.main_loop, thread_idx, warp_idx, lane_idx);
+
+            typename Mma::FragmentC accumulators;
+
+            accumulators.clear();
+
+            if (gemm_k_iterations > 0)
+            {
+                // Compute threadblock-scoped matrix multiply-add
+                mma(gemm_k_iterations, accumulators, iterator_A, iterator_B, iterator_scale, accumulators);
+            }
+
+            //
+            // Epilogue
+            //
+
+            EpilogueOutputOp output_op(params.output_op);
+
+            //
+            // Masked tile iterators constructed from members
+            //
+
+            threadblock_tile_offset = threadblock_swizzle.get_tile_offset(params.swizzle_log_tile);
+
+            // assume identity swizzle
+            MatrixCoord threadblock_offset(
+                threadblock_tile_offset.m() * Mma::Shape::kM, threadblock_tile_offset.n() * Mma::Shape::kN);
+
+            int block_idx = threadblock_tile_offset.m() + threadblock_tile_offset.n() * params.grid_tiled_shape.m();
+
+            ElementC* ptr_C = static_cast<ElementC*>(params.ptr_C);
+            ElementC* ptr_D = static_cast<ElementC*>(params.ptr_D);
+
+            // Tile iterator loading from source tensor.
+            typename Epilogue::OutputTileIterator iterator_C(params.params_C, ptr_C, params.problem_size.mn(),
+                thread_idx, threadblock_offset, params.scatter_D_indices);
+
+            // Tile iterator writing to destination tensor.
+            typename Epilogue::OutputTileIterator iterator_D(params.params_D, ptr_D, params.problem_size.mn(),
+                thread_idx, threadblock_offset, params.scatter_D_indices);
+
+            typename Epilogue::ElementTensor* ptr_Tensor
+                = static_cast<typename Epilogue::ElementTensor*>(params.ptr_Tensor);
+
+            // Define the reduction output pointer and move to the appropriate place
+            typename Epilogue::ElementVector* ptr_Vector
+                = static_cast<typename Epilogue::ElementVector*>(params.ptr_Vector);
+
+            typename Epilogue::TensorTileIterator tensor_iterator(params.params_Tensor,
+                // Only the final block outputs Tensor
+                ptr_Tensor, params.problem_size.mn(), thread_idx, threadblock_offset);
+
+            Epilogue epilogue(shared_storage.epilogue, thread_idx, warp_idx, lane_idx);
+
+            if (ptr_Vector)
+            {
+                ptr_Vector += threadblock_offset.column() + threadblock_tile_offset.m() * params.ldr;
+            }
+
+            epilogue(output_op, ptr_Vector, iterator_D, accumulators, iterator_C, tensor_iterator,
+                params.problem_size.mn(), threadblock_offset);
+        }
+    };
+
+    /*
+        To improve compilation speed, we do not compile the device operator if the
+       CUDA_ARCH does not correspond to the ArchTag of the cutlass kernel
+       operator.
+      */
+    /// Executes one GEMM
+    CUTLASS_DEVICE
+    void operator()(Params const& params, SharedStorage& shared_storage)
+    {
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 700) && (__CUDA_ARCH__ < 750)
-    static constexpr bool compile_needed =
-        platform::is_same<KernelArch, arch::Sm70>::value;
-    KernelRunner<compile_needed>::run_kernel(params, shared_storage);
+        static constexpr bool compile_needed = platform::is_same<KernelArch, arch::Sm70>::value;
+        KernelRunner<compile_needed>::run_kernel(params, shared_storage);
 #elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 750) && (__CUDA_ARCH__ < 800)
-    static constexpr bool compile_needed =
-        platform::is_same<KernelArch, arch::Sm75>::value;
-    KernelRunner<compile_needed>::run_kernel(params, shared_storage);
+        static constexpr bool compile_needed = platform::is_same<KernelArch, arch::Sm75>::value;
+        KernelRunner<compile_needed>::run_kernel(params, shared_storage);
 #elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && (__CUDA_ARCH__ < 900)
-    static constexpr bool compile_needed =
-        platform::is_same<KernelArch, arch::Sm80>::value;
-    KernelRunner<compile_needed>::run_kernel(params, shared_storage);
+        static constexpr bool compile_needed = platform::is_same<KernelArch, arch::Sm80>::value;
+        KernelRunner<compile_needed>::run_kernel(params, shared_storage);
 #else
-    CUTLASS_NOT_IMPLEMENTED();
+        CUTLASS_NOT_IMPLEMENTED();
 #endif
-  }
+    }
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cutlass_extensions/include/cutlass_extensions/gemm/kernel/mixed_gemm_B_layout.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/kernel/mixed_gemm_B_layout.h
@@ -19,71 +19,80 @@
 #include "cutlass_extensions/arch/mma.h"
 #include "cutlass_extensions/tile_interleaved_layout.h"
 
-namespace cutlass {
-namespace gemm {
-namespace kernel {
+namespace cutlass
+{
+namespace gemm
+{
+namespace kernel
+{
 
-template<typename TypeB, typename Arch, typename Enable = void>
-struct LayoutDetailsB {
+template <typename TypeB, typename Arch, typename Enable = void>
+struct LayoutDetailsB
+{
 };
 
 // Volta specialiations. Volta will dequantize before STS, so we need a different operator
-template<typename TypeB>
-struct LayoutDetailsB<TypeB, arch::Sm70> {
-    static constexpr int ThreadblockK      = 64;
-    using Layout                           = layout::RowMajor;
+template <typename TypeB>
+struct LayoutDetailsB<TypeB, arch::Sm70>
+{
+    static constexpr int ThreadblockK = 64;
+    using Layout = layout::RowMajor;
     static constexpr int ElementsPerAccess = 8;
-    using Operator                         = cutlass::arch::OpMultiplyAdd;
+    using Operator = cutlass::arch::OpMultiplyAdd;
 };
 
 // Specializations for Turing+ when B is FP16. These are currently only used for MoE networks.
 // TODO - Switch this to column major for weights since gemms should be more performant.
-template<typename Arch>
-struct LayoutDetailsB<half_t, Arch, typename platform::enable_if<Arch::kMinComputeCapability >= 75>::type> {
-    static constexpr int ThreadblockK      = 64;
-    using Layout                           = layout::RowMajor;
+template <typename Arch>
+struct LayoutDetailsB<half_t, Arch, typename platform::enable_if<Arch::kMinComputeCapability >= 75>::type>
+{
+    static constexpr int ThreadblockK = 64;
+    using Layout = layout::RowMajor;
     static constexpr int ElementsPerAccess = 128 / cutlass::sizeof_bits<half_t>::value;
-    using Operator                         = cutlass::arch::OpMultiplyAdd;
+    using Operator = cutlass::arch::OpMultiplyAdd;
 };
 
-template<typename Arch>
-struct LayoutDetailsB<bfloat16_t, Arch, typename platform::enable_if<Arch::kMinComputeCapability >= 75>::type> {
-    static constexpr int ThreadblockK      = 64;
-    using Layout                           = layout::RowMajor;
+template <typename Arch>
+struct LayoutDetailsB<bfloat16_t, Arch, typename platform::enable_if<Arch::kMinComputeCapability >= 75>::type>
+{
+    static constexpr int ThreadblockK = 64;
+    using Layout = layout::RowMajor;
     static constexpr int ElementsPerAccess = 128 / cutlass::sizeof_bits<bfloat16_t>::value;
-    using Operator                         = cutlass::arch::OpMultiplyAdd;
+    using Operator = cutlass::arch::OpMultiplyAdd;
 };
 
 // Specializations for Turing+ when B is quantized. These can use the operator OpMultiplyAddDequantizeInterleavedBToA,
 // which signals that we want to dequantize after loading from smem.
-template<typename Arch>
-struct LayoutDetailsB<uint8_t, Arch, typename platform::enable_if<Arch::kMinComputeCapability >= 75>::type> {
+template <typename Arch>
+struct LayoutDetailsB<uint8_t, Arch, typename platform::enable_if<Arch::kMinComputeCapability >= 75>::type>
+{
     static constexpr int ThreadblockK = 64;
 
 private:
     static constexpr int ElementsPerCacheLine = 128 * 8 / sizeof_bits<uint8_t>::value;
-    static constexpr int ColumnsInterleaved   = ElementsPerCacheLine / ThreadblockK;
+    static constexpr int ColumnsInterleaved = ElementsPerCacheLine / ThreadblockK;
 
 public:
-    using Layout                           = layout::ColumnMajorTileInterleave<ThreadblockK, ColumnsInterleaved>;
+    using Layout = layout::ColumnMajorTileInterleave<ThreadblockK, ColumnsInterleaved>;
     static constexpr int ElementsPerAccess = 128 / cutlass::sizeof_bits<uint8_t>::value;
-    using Operator                         = cutlass::arch::OpMultiplyAddDequantizeInterleavedBToA;
+    using Operator = cutlass::arch::OpMultiplyAddDequantizeInterleavedBToA;
 };
 
-template<typename Arch>
-struct LayoutDetailsB<uint4b_t, Arch, typename platform::enable_if<Arch::kMinComputeCapability >= 75>::type> {
+template <typename Arch>
+struct LayoutDetailsB<uint4b_t, Arch, typename platform::enable_if<Arch::kMinComputeCapability >= 75>::type>
+{
     static constexpr int ThreadblockK = 64;
 
 private:
     static constexpr int ElementsPerCacheLine = 128 * 8 / sizeof_bits<uint4b_t>::value;
-    static constexpr int ColumnsInterleaved   = ElementsPerCacheLine / ThreadblockK;
+    static constexpr int ColumnsInterleaved = ElementsPerCacheLine / ThreadblockK;
 
 public:
-    using Layout                           = layout::ColumnMajorTileInterleave<ThreadblockK, ColumnsInterleaved>;
+    using Layout = layout::ColumnMajorTileInterleave<ThreadblockK, ColumnsInterleaved>;
     static constexpr int ElementsPerAccess = 128 / cutlass::sizeof_bits<uint4b_t>::value;
-    using Operator                         = cutlass::arch::OpMultiplyAddDequantizeInterleavedBToA;
+    using Operator = cutlass::arch::OpMultiplyAddDequantizeInterleavedBToA;
 };
 
-}  // namespace kernel
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace kernel
+} // namespace gemm
+} // namespace cutlass

--- a/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/default_dq_mma.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/default_dq_mma.h
@@ -3,62 +3,65 @@
 #include "cutlass_extensions/arch/mma.h"
 #include "cutlass_extensions/interleaved_numeric_conversion.h"
 
-namespace cutlass {
-namespace gemm {
-namespace threadblock {
+namespace cutlass
+{
+namespace gemm
+{
+namespace threadblock
+{
 ////////////////////////////////////////////////////////////////////////////////
 
 // We need to distinguish here, since we want volta support. It is too much effort
 // to write shared memory iterators that are probably needed for volta to function
 // properly. As a result, we allow converters both after the LDG (for volta) and after
 // the LDS for Turing+.
-template<
+template <
     /// Iterator for B matrix in global memory
     typename IteratorB,
     /// Warp level Mma
     typename MmaOperator,
     /// Math operation perform by warp level operator
     typename MathOperator>
-struct SetConverters {
+struct SetConverters
+{
 };
 
 // Dequantize after LDG, so set transforms accordingly
-template<
+template <
     /// Iterator for B matrix in global memory
     typename IteratorB,
     /// Mma Policy
     typename MmaOperator>
-struct SetConverters<IteratorB, MmaOperator, arch::OpMultiplyAdd> {
-    using TransformAfterLDG =
-        FastInterleavedAndBiasedNumericArrayConverter<typename MmaOperator::ArchMmaOperator::ElementB,
-                                                      typename IteratorB::Element,
-                                                      IteratorB::Fragment::kElements>;
+struct SetConverters<IteratorB, MmaOperator, arch::OpMultiplyAdd>
+{
+    using TransformAfterLDG
+        = FastInterleavedAndBiasedNumericArrayConverter<typename MmaOperator::ArchMmaOperator::ElementB,
+            typename IteratorB::Element, IteratorB::Fragment::kElements>;
 
     using TransformAfterLDS = NumericArrayConverter<typename MmaOperator::ArchMmaOperator::ElementB,
-                                                    typename MmaOperator::ArchMmaOperator::ElementB,
-                                                    MmaOperator::FragmentB::kElements>;
+        typename MmaOperator::ArchMmaOperator::ElementB, MmaOperator::FragmentB::kElements>;
 };
 
 // Dequantize after LDS, so set transforms accordingly
 
-template<
+template <
     /// Iterator for B matrix in global memory
     typename IteratorB,
     /// Mma Policy
     typename MmaOperator>
-struct SetConverters<IteratorB, MmaOperator, arch::OpMultiplyAddDequantizeInterleavedBToA> {
-    using TransformAfterLDG =
-        NumericArrayConverter<typename IteratorB::Element, typename IteratorB::Element, IteratorB::Fragment::kElements>;
+struct SetConverters<IteratorB, MmaOperator, arch::OpMultiplyAddDequantizeInterleavedBToA>
+{
+    using TransformAfterLDG = NumericArrayConverter<typename IteratorB::Element, typename IteratorB::Element,
+        IteratorB::Fragment::kElements>;
 
-    using TransformAfterLDS =
-        FastInterleavedAndBiasedNumericArrayConverter<typename MmaOperator::ArchMmaOperator::ElementB,
-                                                      typename TransformAfterLDG::result_type::Element,
-                                                      MmaOperator::FragmentB::kElements>;
+    using TransformAfterLDS
+        = FastInterleavedAndBiasedNumericArrayConverter<typename MmaOperator::ArchMmaOperator::ElementB,
+            typename TransformAfterLDG::result_type::Element, MmaOperator::FragmentB::kElements>;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template<
+template <
     /// Element type for A matrix operand
     typename ElementA_,
     /// Layout type for A matrix operand
@@ -101,6 +104,6 @@ template<
     typename Enable = void>
 struct DqMma;
 
-}  // namespace threadblock
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace threadblock
+} // namespace gemm
+} // namespace cutlass

--- a/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/default_dq_mma_multistage.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/default_dq_mma_multistage.h
@@ -10,13 +10,16 @@
 
 #include "cutlass_extensions/gemm/threadblock/default_dq_mma.h"
 
-namespace cutlass {
-namespace gemm {
-namespace threadblock {
+namespace cutlass
+{
+namespace gemm
+{
+namespace threadblock
+{
 
 ////////////////////////////////////////////////////////////////////////////////
 
-template<
+template <
     /// Type for elementA
     typename ElementA,
     /// Layout type for A matrix operand
@@ -53,125 +56,72 @@ template<
     typename Operator,
     ///
     SharedMemoryClearOption SharedMemoryClear>
-struct DqMma<ElementA,
-             LayoutA,
-             kAlignmentA,
-             ElementB,
-             LayoutB,
-             kAlignmentB,
-             ElementScale,
-             LayoutScale,
-             kAlignmentScale,
-             ElementAccumulator,
-             layout::RowMajor,
-             OperatorClass,
-             ArchTag,
-             ThreadblockShape,
-             WarpShape,
-             InstructionShape,
-             kStages,
-             Operator,
-             SharedMemoryClear,
-             typename platform::enable_if<(ArchTag::kMinComputeCapability >= 80)>::type> {
+struct DqMma<ElementA, LayoutA, kAlignmentA, ElementB, LayoutB, kAlignmentB, ElementScale, LayoutScale, kAlignmentScale,
+    ElementAccumulator, layout::RowMajor, OperatorClass, ArchTag, ThreadblockShape, WarpShape, InstructionShape,
+    kStages, Operator, SharedMemoryClear, typename platform::enable_if<(ArchTag::kMinComputeCapability >= 80)>::type>
+{
 
     static_assert(platform::is_same<ElementA, half_t>::value || platform::is_same<ElementA, bfloat16_t>::value,
-                  "Element A must be fp16 or bf16");
+        "Element A must be fp16 or bf16");
 
     static_assert(platform::is_same<Operator, arch::OpMultiplyAddDequantizeInterleavedBToA>::value,
-                  "Mma multistage must dequantize after ldsm");
+        "Mma multistage must dequantize after ldsm");
 
     static_assert(platform::is_same<ElementB, uint8_t>::value || platform::is_same<ElementB, uint4b_t>::value,
-                  "Element B must be uint8 or uint4");
+        "Element B must be uint8 or uint4");
 
-    static cutlass::arch::CacheOperation::Kind const CacheOpA = ((sizeof_bits<ElementA>::value * kAlignmentA) == 128) ?
-                                                                    cutlass::arch::CacheOperation::Global :
-                                                                    cutlass::arch::CacheOperation::Always;
+    static cutlass::arch::CacheOperation::Kind const CacheOpA = ((sizeof_bits<ElementA>::value * kAlignmentA) == 128)
+        ? cutlass::arch::CacheOperation::Global
+        : cutlass::arch::CacheOperation::Always;
 
-    static cutlass::arch::CacheOperation::Kind const CacheOpB = ((sizeof_bits<ElementB>::value * kAlignmentB) == 128) ?
-                                                                    cutlass::arch::CacheOperation::Global :
-                                                                    cutlass::arch::CacheOperation::Always;
+    static cutlass::arch::CacheOperation::Kind const CacheOpB = ((sizeof_bits<ElementB>::value * kAlignmentB) == 128)
+        ? cutlass::arch::CacheOperation::Global
+        : cutlass::arch::CacheOperation::Always;
 
     // Define the MmaCore components
     // Mma core does not depend on stages, so pass in at least 3 here to mma multistage pieces are created
-    using MmaCore = typename cutlass::gemm::threadblock::DefaultMmaCore<ThreadblockShape,
-                                                                        WarpShape,
-                                                                        InstructionShape,
-                                                                        ElementA,
-                                                                        LayoutA,
-                                                                        ElementB,
-                                                                        LayoutB,
-                                                                        ElementAccumulator,
-                                                                        layout::RowMajor,
-                                                                        OperatorClass,
-                                                                        std::max(kStages, 3),
-                                                                        Operator,
-                                                                        false,
-                                                                        CacheOpA,
-                                                                        CacheOpB>;
+    using MmaCore = typename cutlass::gemm::threadblock::DefaultMmaCore<ThreadblockShape, WarpShape, InstructionShape,
+        ElementA, LayoutA, ElementB, LayoutB, ElementAccumulator, layout::RowMajor, OperatorClass, std::max(kStages, 3),
+        Operator, false, CacheOpA, CacheOpB>;
 
     // Define iterators over tiles from the A operand
-    using ThreadMapA  = typename MmaCore::IteratorThreadMapA;
+    using ThreadMapA = typename MmaCore::IteratorThreadMapA;
     using AccessTypeA = cutlass::Array<ElementA, kAlignmentA>;
-    using IteratorA   = cutlass::transform::threadblock::PredicatedTileAccessIterator<
-        cutlass::MatrixShape<ThreadblockShape::kM, ThreadblockShape::kK>,
-        ElementA,
-        LayoutA,
-        1,
-        ThreadMapA,
+    using IteratorA = cutlass::transform::threadblock::PredicatedTileAccessIterator<
+        cutlass::MatrixShape<ThreadblockShape::kM, ThreadblockShape::kK>, ElementA, LayoutA, 1, ThreadMapA,
         AccessTypeA>;
 
     // Define iterators over tiles from the B operand
-    using ThreadMapB  = typename MmaCore::IteratorThreadMapB;
+    using ThreadMapB = typename MmaCore::IteratorThreadMapB;
     using AccessTypeB = cutlass::Array<ElementB, kAlignmentB>;
-    using IteratorB   = cutlass::transform::threadblock::PredicatedTileAccessIterator<
-        cutlass::MatrixShape<ThreadblockShape::kK, ThreadblockShape::kN>,
-        ElementB,
-        LayoutB,
-        0,
-        ThreadMapB,
+    using IteratorB = cutlass::transform::threadblock::PredicatedTileAccessIterator<
+        cutlass::MatrixShape<ThreadblockShape::kK, ThreadblockShape::kN>, ElementB, LayoutB, 0, ThreadMapB,
         AccessTypeB>;
 
     // ThreadMap for scale iterator
     static_assert((MmaCore::Shape::kN % kAlignmentScale) == 0, "");
-    using IteratorScaleThreadMap =
-        transform::PitchLinearStripminedThreadMap<layout::PitchLinearShape<MmaCore::Shape::kN, 1>,
-                                                  MmaCore::Shape::kN / kAlignmentScale,
-                                                  kAlignmentScale>;
+    using IteratorScaleThreadMap
+        = transform::PitchLinearStripminedThreadMap<layout::PitchLinearShape<MmaCore::Shape::kN, 1>,
+            MmaCore::Shape::kN / kAlignmentScale, kAlignmentScale>;
 
     // Define iterators over tiles from the scale operand
-    using IteratorScale =
-        cutlass::transform::threadblock::PredicatedTileIterator<cutlass::MatrixShape<1, MmaCore::Shape::kN>,
-                                                                ElementScale,
-                                                                LayoutScale,
-                                                                0,
-                                                                IteratorScaleThreadMap,
-                                                                kAlignmentScale>;
+    using IteratorScale
+        = cutlass::transform::threadblock::PredicatedTileIterator<cutlass::MatrixShape<1, MmaCore::Shape::kN>,
+            ElementScale, LayoutScale, 0, IteratorScaleThreadMap, kAlignmentScale>;
 
     using SmemIteratorScale = IteratorScale;
 
-    using Converter = FastInterleavedAndBiasedNumericArrayConverter<ElementA,
-                                                                    ElementB,
-                                                                    MmaCore::MmaPolicy::Operator::FragmentB::kElements>;
+    using Converter = FastInterleavedAndBiasedNumericArrayConverter<ElementA, ElementB,
+        MmaCore::MmaPolicy::Operator::FragmentB::kElements>;
 
     // Define the threadblock-scoped pipelined matrix multiply
-    using ThreadblockMma = cutlass::gemm::threadblock::DqMmaMultistage<typename MmaCore::Shape,
-                                                                       IteratorA,
-                                                                       typename MmaCore::SmemIteratorA,
-                                                                       MmaCore::kCacheOpA,
-                                                                       IteratorB,
-                                                                       typename MmaCore::SmemIteratorB,
-                                                                       MmaCore::kCacheOpB,
-                                                                       IteratorScale,
-                                                                       SmemIteratorScale,
-                                                                       ElementAccumulator,
-                                                                       layout::RowMajor,
-                                                                       typename MmaCore::MmaPolicy,
-                                                                       kStages,
-                                                                       Converter,
-                                                                       SharedMemoryClear>;
+    using ThreadblockMma = cutlass::gemm::threadblock::DqMmaMultistage<typename MmaCore::Shape, IteratorA,
+        typename MmaCore::SmemIteratorA, MmaCore::kCacheOpA, IteratorB, typename MmaCore::SmemIteratorB,
+        MmaCore::kCacheOpB, IteratorScale, SmemIteratorScale, ElementAccumulator, layout::RowMajor,
+        typename MmaCore::MmaPolicy, kStages, Converter, SharedMemoryClear>;
 };
 
-template<
+template <
     /// Type for element A
     typename ElementA,
     /// Layout type for A matrix operand
@@ -210,137 +160,89 @@ template<
     int RowsPerTile,
     ///
     int ColumnsInterleaved>
-struct DqMma<ElementA,
-             LayoutA,
-             kAlignmentA,
-             ElementB,
-             layout::ColumnMajorTileInterleave<RowsPerTile, ColumnsInterleaved>,
-             kAlignmentB,
-             ElementScale,
-             LayoutScale,
-             kAlignmentScale,
-             ElementAccumulator,
-             layout::RowMajor,
-             OperatorClass,
-             ArchTag,
-             ThreadblockShape,
-             WarpShape,
-             InstructionShape,
-             kStages,
-             Operator,
-             SharedMemoryClear,
-             typename platform::enable_if<(ArchTag::kMinComputeCapability >= 80)>::type> {
+struct DqMma<ElementA, LayoutA, kAlignmentA, ElementB,
+    layout::ColumnMajorTileInterleave<RowsPerTile, ColumnsInterleaved>, kAlignmentB, ElementScale, LayoutScale,
+    kAlignmentScale, ElementAccumulator, layout::RowMajor, OperatorClass, ArchTag, ThreadblockShape, WarpShape,
+    InstructionShape, kStages, Operator, SharedMemoryClear,
+    typename platform::enable_if<(ArchTag::kMinComputeCapability >= 80)>::type>
+{
 
     static_assert(platform::is_same<ElementA, half_t>::value || platform::is_same<ElementA, bfloat16_t>::value,
-                  "Element A must be fp16 or bf16");
+        "Element A must be fp16 or bf16");
 
     static_assert(platform::is_same<Operator, arch::OpMultiplyAddDequantizeInterleavedBToA>::value,
-                  "Mma multistage must dequantize after ldsm");
+        "Mma multistage must dequantize after ldsm");
 
     static_assert(platform::is_same<ElementB, uint8_t>::value || platform::is_same<ElementB, uint4b_t>::value,
-                  "Element B must be uint8 or uint4");
+        "Element B must be uint8 or uint4");
 
-    static cutlass::arch::CacheOperation::Kind const CacheOpA = ((sizeof_bits<ElementA>::value * kAlignmentA) == 128) ?
-                                                                    cutlass::arch::CacheOperation::Global :
-                                                                    cutlass::arch::CacheOperation::Always;
+    static cutlass::arch::CacheOperation::Kind const CacheOpA = ((sizeof_bits<ElementA>::value * kAlignmentA) == 128)
+        ? cutlass::arch::CacheOperation::Global
+        : cutlass::arch::CacheOperation::Always;
 
-    static cutlass::arch::CacheOperation::Kind const CacheOpB = ((sizeof_bits<ElementB>::value * kAlignmentB) == 128) ?
-                                                                    cutlass::arch::CacheOperation::Global :
-                                                                    cutlass::arch::CacheOperation::Always;
+    static cutlass::arch::CacheOperation::Kind const CacheOpB = ((sizeof_bits<ElementB>::value * kAlignmentB) == 128)
+        ? cutlass::arch::CacheOperation::Global
+        : cutlass::arch::CacheOperation::Always;
 
     // Define the MmaCore components
     // Mma core does not depend on stages, so pass in at least 3 here to mma multistage pieces are created
-    using MmaCore = typename cutlass::gemm::threadblock::DefaultMmaCore<ThreadblockShape,
-                                                                        WarpShape,
-                                                                        InstructionShape,
-                                                                        ElementA,
-                                                                        LayoutA,
-                                                                        ElementB,
-                                                                        layout::ColumnMajor,
-                                                                        ElementAccumulator,
-                                                                        layout::RowMajor,
-                                                                        OperatorClass,
-                                                                        std::max(kStages, 3),
-                                                                        Operator,
-                                                                        false,
-                                                                        CacheOpA,
-                                                                        CacheOpB>;
+    using MmaCore = typename cutlass::gemm::threadblock::DefaultMmaCore<ThreadblockShape, WarpShape, InstructionShape,
+        ElementA, LayoutA, ElementB, layout::ColumnMajor, ElementAccumulator, layout::RowMajor, OperatorClass,
+        std::max(kStages, 3), Operator, false, CacheOpA, CacheOpB>;
 
     // Define iterators over tiles from the A operand
-    using ThreadMapA  = typename MmaCore::IteratorThreadMapA;
+    using ThreadMapA = typename MmaCore::IteratorThreadMapA;
     using AccessTypeA = cutlass::Array<ElementA, kAlignmentA>;
-    using IteratorA   = cutlass::transform::threadblock::PredicatedTileAccessIterator<
-        cutlass::MatrixShape<ThreadblockShape::kM, ThreadblockShape::kK>,
-        ElementA,
-        LayoutA,
-        1,
-        ThreadMapA,
+    using IteratorA = cutlass::transform::threadblock::PredicatedTileAccessIterator<
+        cutlass::MatrixShape<ThreadblockShape::kM, ThreadblockShape::kK>, ElementA, LayoutA, 1, ThreadMapA,
         AccessTypeA>;
 
 private:
     static_assert(!(MmaCore::Shape::kN % ColumnsInterleaved), "");
     static_assert(RowsPerTile == MmaCore::Shape::kK, "");
 
-    using OriginalThreadMap       = typename MmaCore::IteratorThreadMapB;
+    using OriginalThreadMap = typename MmaCore::IteratorThreadMapB;
     using OriginalWarpArrangement = typename OriginalThreadMap::Detail::WarpThreadArrangement;
     static_assert(!(OriginalWarpArrangement::kStrided % ColumnsInterleaved), "");
 
-    using GmemIteratorShape =
-        MatrixShape<MmaCore::Shape::kK * ColumnsInterleaved, MmaCore::Shape::kN / ColumnsInterleaved>;
+    using GmemIteratorShape
+        = MatrixShape<MmaCore::Shape::kK * ColumnsInterleaved, MmaCore::Shape::kN / ColumnsInterleaved>;
     using GmemThreadMapB = transform::PitchLinearWarpRakedThreadMap<
-        layout::PitchLinearShape<GmemIteratorShape::kRow, GmemIteratorShape::kColumn>,
-        OriginalThreadMap::kThreads,
+        layout::PitchLinearShape<GmemIteratorShape::kRow, GmemIteratorShape::kColumn>, OriginalThreadMap::kThreads,
         layout::PitchLinearShape<OriginalWarpArrangement::kContiguous * ColumnsInterleaved,
-                                 OriginalWarpArrangement::kStrided / ColumnsInterleaved>,
+            OriginalWarpArrangement::kStrided / ColumnsInterleaved>,
         MmaCore::kAccessSizeInBits / sizeof_bits<ElementB>::value>;
 
 public:
     // Define iterators over tiles from the B operand
-    using ThreadMapB  = typename MmaCore::IteratorThreadMapB;
+    using ThreadMapB = typename MmaCore::IteratorThreadMapB;
     using AccessTypeB = cutlass::Array<ElementB, kAlignmentB>;
-    using IteratorB   = cutlass::transform::threadblock::
-        PredicatedTileAccessIterator<GmemIteratorShape, ElementB, layout::ColumnMajor, 0, GmemThreadMapB, AccessTypeB>;
+    using IteratorB = cutlass::transform::threadblock::PredicatedTileAccessIterator<GmemIteratorShape, ElementB,
+        layout::ColumnMajor, 0, GmemThreadMapB, AccessTypeB>;
 
     // ThreadMap for scale iterator
     static_assert((MmaCore::Shape::kN % kAlignmentScale) == 0, "");
-    using IteratorScaleThreadMap =
-        transform::PitchLinearStripminedThreadMap<layout::PitchLinearShape<MmaCore::Shape::kN, 1>,
-                                                  MmaCore::Shape::kN / kAlignmentScale,
-                                                  kAlignmentScale>;
+    using IteratorScaleThreadMap
+        = transform::PitchLinearStripminedThreadMap<layout::PitchLinearShape<MmaCore::Shape::kN, 1>,
+            MmaCore::Shape::kN / kAlignmentScale, kAlignmentScale>;
 
     // Define iterators over tiles from the scale operand
-    using IteratorScale =
-        cutlass::transform::threadblock::PredicatedTileIterator<cutlass::MatrixShape<1, MmaCore::Shape::kN>,
-                                                                ElementScale,
-                                                                LayoutScale,
-                                                                0,
-                                                                IteratorScaleThreadMap,
-                                                                kAlignmentScale>;
+    using IteratorScale
+        = cutlass::transform::threadblock::PredicatedTileIterator<cutlass::MatrixShape<1, MmaCore::Shape::kN>,
+            ElementScale, LayoutScale, 0, IteratorScaleThreadMap, kAlignmentScale>;
 
     using SmemIteratorScale = IteratorScale;
 
-    using Converter = FastInterleavedAndBiasedNumericArrayConverter<ElementA,
-                                                                    ElementB,
-                                                                    MmaCore::MmaPolicy::Operator::FragmentB::kElements>;
+    using Converter = FastInterleavedAndBiasedNumericArrayConverter<ElementA, ElementB,
+        MmaCore::MmaPolicy::Operator::FragmentB::kElements>;
 
     // Define the threadblock-scoped pipelined matrix multiply
-    using ThreadblockMma = cutlass::gemm::threadblock::DqMmaMultistage<typename MmaCore::Shape,
-                                                                       IteratorA,
-                                                                       typename MmaCore::SmemIteratorA,
-                                                                       MmaCore::kCacheOpA,
-                                                                       IteratorB,
-                                                                       typename MmaCore::SmemIteratorB,
-                                                                       MmaCore::kCacheOpB,
-                                                                       IteratorScale,
-                                                                       SmemIteratorScale,
-                                                                       ElementAccumulator,
-                                                                       layout::RowMajor,
-                                                                       typename MmaCore::MmaPolicy,
-                                                                       kStages,
-                                                                       Converter,
-                                                                       SharedMemoryClear>;
+    using ThreadblockMma = cutlass::gemm::threadblock::DqMmaMultistage<typename MmaCore::Shape, IteratorA,
+        typename MmaCore::SmemIteratorA, MmaCore::kCacheOpA, IteratorB, typename MmaCore::SmemIteratorB,
+        MmaCore::kCacheOpB, IteratorScale, SmemIteratorScale, ElementAccumulator, layout::RowMajor,
+        typename MmaCore::MmaPolicy, kStages, Converter, SharedMemoryClear>;
 };
 
-}  // namespace threadblock
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace threadblock
+} // namespace gemm
+} // namespace cutlass

--- a/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/default_mma.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/default_mma.h
@@ -4,14 +4,17 @@
 #include "cutlass_extensions/gemm/threadblock/default_dq_mma_pipelined.h"
 #include "cutlass_extensions/gemm/threadblock/default_mma_bf16.h"
 
-namespace cutlass {
-namespace gemm {
-namespace threadblock {
+namespace cutlass
+{
+namespace gemm
+{
+namespace threadblock
+{
 
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Specialization for row-major output (OperatorClass TensorOp), fp16 activation & int8 weight
-template<
+template <
     /// Layout type for A matrix operand
     typename LayoutA,
     /// Access granularity of A matrix in units of elements
@@ -32,43 +35,16 @@ template<
     typename InstructionShape,
     /// Operation performed by GEMM
     typename Operator>
-struct DefaultMma<cutlass::half_t,
-                  LayoutA,
-                  kAlignmentA,
-                  uint8_t,
-                  LayoutB,
-                  kAlignmentB,
-                  ElementAccumulator,
-                  layout::RowMajor,
-                  arch::OpClassTensorOp,
-                  ArchTag,
-                  ThreadblockShape,
-                  WarpShape,
-                  InstructionShape,
-                  2,
-                  Operator> {
+struct DefaultMma<cutlass::half_t, LayoutA, kAlignmentA, uint8_t, LayoutB, kAlignmentB, ElementAccumulator,
+    layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, 2, Operator>
+{
 
 private:
     static constexpr int kAlignmentScale = 128 / sizeof_bits<half_t>::value;
 
-    using Mma = DqMma<half_t,
-                      LayoutA,
-                      kAlignmentA,
-                      uint8_t,
-                      LayoutB,
-                      kAlignmentB,
-                      half_t,
-                      layout::RowMajor,
-                      kAlignmentScale,
-                      ElementAccumulator,
-                      layout::RowMajor,
-                      arch::OpClassTensorOp,
-                      ArchTag,
-                      ThreadblockShape,
-                      WarpShape,
-                      InstructionShape,
-                      2,
-                      Operator>;
+    using Mma = DqMma<half_t, LayoutA, kAlignmentA, uint8_t, LayoutB, kAlignmentB, half_t, layout::RowMajor,
+        kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+        WarpShape, InstructionShape, 2, Operator>;
 
 public:
     // Define the MmaCore components
@@ -86,7 +62,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Specialization for row-major output (OperatorClass TensorOp), fp16 activation & int4 weight
-template<
+template <
     /// Layout type for A matrix operand
     typename LayoutA,
     /// Access granularity of A matrix in units of elements
@@ -107,43 +83,16 @@ template<
     typename InstructionShape,
     /// Operation performed by GEMM
     typename Operator>
-struct DefaultMma<cutlass::half_t,
-                  LayoutA,
-                  kAlignmentA,
-                  uint4b_t,
-                  LayoutB,
-                  kAlignmentB,
-                  ElementAccumulator,
-                  layout::RowMajor,
-                  arch::OpClassTensorOp,
-                  ArchTag,
-                  ThreadblockShape,
-                  WarpShape,
-                  InstructionShape,
-                  2,
-                  Operator> {
+struct DefaultMma<cutlass::half_t, LayoutA, kAlignmentA, uint4b_t, LayoutB, kAlignmentB, ElementAccumulator,
+    layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, 2, Operator>
+{
 
 private:
     static constexpr int kAlignmentScale = 128 / sizeof_bits<half_t>::value;
 
-    using Mma = DqMma<half_t,
-                      LayoutA,
-                      kAlignmentA,
-                      uint4b_t,
-                      LayoutB,
-                      kAlignmentB,
-                      half_t,
-                      layout::RowMajor,
-                      kAlignmentScale,
-                      ElementAccumulator,
-                      layout::RowMajor,
-                      arch::OpClassTensorOp,
-                      ArchTag,
-                      ThreadblockShape,
-                      WarpShape,
-                      InstructionShape,
-                      2,
-                      Operator>;
+    using Mma = DqMma<half_t, LayoutA, kAlignmentA, uint4b_t, LayoutB, kAlignmentB, half_t, layout::RowMajor,
+        kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+        WarpShape, InstructionShape, 2, Operator>;
 
 public:
     // Define the MmaCore components
@@ -159,7 +108,7 @@ public:
     using ThreadblockMma = typename Mma::ThreadblockMma;
 };
 
-template<
+template <
     /// Layout type for A matrix operand
     typename LayoutA,
     /// Access granularity of A matrix in units of elements
@@ -184,46 +133,17 @@ template<
     int kStages,
     /// Shared memory clear option
     SharedMemoryClearOption SharedMemoryClear>
-struct DefaultMma<cutlass::half_t,
-                  LayoutA,
-                  kAlignmentA,
-                  uint8_t,
-                  LayoutB,
-                  kAlignmentB,
-                  ElementAccumulator,
-                  layout::RowMajor,
-                  arch::OpClassTensorOp,
-                  ArchTag,
-                  ThreadblockShape,
-                  WarpShape,
-                  InstructionShape,
-                  kStages,
-                  Operator,
-                  false,
-                  SharedMemoryClear> {
+struct DefaultMma<cutlass::half_t, LayoutA, kAlignmentA, uint8_t, LayoutB, kAlignmentB, ElementAccumulator,
+    layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, kStages, Operator,
+    false, SharedMemoryClear>
+{
 
 private:
     static constexpr int kAlignmentScale = 128 / sizeof_bits<half_t>::value;
 
-    using Mma = DqMma<half_t,
-                      LayoutA,
-                      kAlignmentA,
-                      uint8_t,
-                      LayoutB,
-                      kAlignmentB,
-                      half_t,
-                      layout::RowMajor,
-                      kAlignmentScale,
-                      ElementAccumulator,
-                      layout::RowMajor,
-                      arch::OpClassTensorOp,
-                      ArchTag,
-                      ThreadblockShape,
-                      WarpShape,
-                      InstructionShape,
-                      kStages,
-                      Operator,
-                      SharedMemoryClear>;
+    using Mma = DqMma<half_t, LayoutA, kAlignmentA, uint8_t, LayoutB, kAlignmentB, half_t, layout::RowMajor,
+        kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+        WarpShape, InstructionShape, kStages, Operator, SharedMemoryClear>;
 
 public:
     // Define the MmaCore components
@@ -241,7 +161,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Specialization for row-major output (OperatorClass TensorOp), fp16 activation & int4 weight
-template<
+template <
     /// Layout type for A matrix operand
     typename LayoutA,
     /// Access granularity of A matrix in units of elements
@@ -266,46 +186,17 @@ template<
     int kStages,
     /// Shared memory clear option
     SharedMemoryClearOption SharedMemoryClear>
-struct DefaultMma<cutlass::half_t,
-                  LayoutA,
-                  kAlignmentA,
-                  uint4b_t,
-                  LayoutB,
-                  kAlignmentB,
-                  ElementAccumulator,
-                  layout::RowMajor,
-                  arch::OpClassTensorOp,
-                  ArchTag,
-                  ThreadblockShape,
-                  WarpShape,
-                  InstructionShape,
-                  kStages,
-                  Operator,
-                  false,
-                  SharedMemoryClear> {
+struct DefaultMma<cutlass::half_t, LayoutA, kAlignmentA, uint4b_t, LayoutB, kAlignmentB, ElementAccumulator,
+    layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, kStages, Operator,
+    false, SharedMemoryClear>
+{
 
 private:
     static constexpr int kAlignmentScale = 128 / sizeof_bits<half_t>::value;
 
-    using Mma = DqMma<half_t,
-                      LayoutA,
-                      kAlignmentA,
-                      uint4b_t,
-                      LayoutB,
-                      kAlignmentB,
-                      half_t,
-                      layout::RowMajor,
-                      kAlignmentScale,
-                      ElementAccumulator,
-                      layout::RowMajor,
-                      arch::OpClassTensorOp,
-                      ArchTag,
-                      ThreadblockShape,
-                      WarpShape,
-                      InstructionShape,
-                      kStages,
-                      Operator,
-                      SharedMemoryClear>;
+    using Mma = DqMma<half_t, LayoutA, kAlignmentA, uint4b_t, LayoutB, kAlignmentB, half_t, layout::RowMajor,
+        kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+        WarpShape, InstructionShape, kStages, Operator, SharedMemoryClear>;
 
 public:
     // Define the MmaCore components
@@ -323,7 +214,7 @@ public:
 
 // fp16 x fp16 specialization on Ampere to use mma multistage for 2 stage. Helps avoid reg spills on
 // large tile when not enough shared mem is present to do 3+ stage
-template<
+template <
     /// Layout type for A matrix operand
     typename LayoutA,
     /// Access granularity of A matrix in units of elements
@@ -348,79 +239,36 @@ template<
     bool GatherA,
     /// Gather operand B by using an index array
     bool GatherB>
-struct DefaultMma<half_t,
-                  LayoutA,
-                  kAlignmentA,
-                  half_t,
-                  LayoutB,
-                  kAlignmentB,
-                  ElementAccumulator,
-                  layout::RowMajor,
-                  arch::OpClassTensorOp,
-                  arch::Sm80,
-                  ThreadblockShape,
-                  WarpShape,
-                  InstructionShape,
-                  2,
-                  Operator,
-                  false,
-                  SharedMemoryClear,
-                  GatherA,
-                  GatherB> {
+struct DefaultMma<half_t, LayoutA, kAlignmentA, half_t, LayoutB, kAlignmentB, ElementAccumulator, layout::RowMajor,
+    arch::OpClassTensorOp, arch::Sm80, ThreadblockShape, WarpShape, InstructionShape, 2, Operator, false,
+    SharedMemoryClear, GatherA, GatherB>
+{
 
     // Define the MmaCore components
     // 3 is used on purpose here to trigger components for mma multistage
-    using MmaCore = typename cutlass::gemm::threadblock::DefaultMmaCore<ThreadblockShape,
-                                                                        WarpShape,
-                                                                        InstructionShape,
-                                                                        half_t,
-                                                                        LayoutA,
-                                                                        half_t,
-                                                                        LayoutB,
-                                                                        ElementAccumulator,
-                                                                        layout::RowMajor,
-                                                                        arch::OpClassTensorOp,
-                                                                        3,
-                                                                        Operator>;
+    using MmaCore = typename cutlass::gemm::threadblock::DefaultMmaCore<ThreadblockShape, WarpShape, InstructionShape,
+        half_t, LayoutA, half_t, LayoutB, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, 3, Operator>;
 
     // Define iterators over tiles from the A operand
-    using ThreadMapA  = typename MmaCore::IteratorThreadMapA;
+    using ThreadMapA = typename MmaCore::IteratorThreadMapA;
     using AccessTypeA = cutlass::Array<half_t, kAlignmentA>;
-    using IteratorA   = cutlass::transform::threadblock::PredicatedTileAccessIterator<
-        cutlass::MatrixShape<ThreadblockShape::kM, ThreadblockShape::kK>,
-        half_t,
-        LayoutA,
-        1,
-        ThreadMapA,
-        AccessTypeA,
+    using IteratorA = cutlass::transform::threadblock::PredicatedTileAccessIterator<
+        cutlass::MatrixShape<ThreadblockShape::kM, ThreadblockShape::kK>, half_t, LayoutA, 1, ThreadMapA, AccessTypeA,
         GatherA>;
 
     // Define iterators over tiles from the B operand
-    using ThreadMapB  = typename MmaCore::IteratorThreadMapB;
+    using ThreadMapB = typename MmaCore::IteratorThreadMapB;
     using AccessTypeB = cutlass::Array<half_t, kAlignmentB>;
-    using IteratorB   = cutlass::transform::threadblock::PredicatedTileAccessIterator<
-        cutlass::MatrixShape<ThreadblockShape::kK, ThreadblockShape::kN>,
-        half_t,
-        LayoutB,
-        0,
-        ThreadMapB,
-        AccessTypeB,
+    using IteratorB = cutlass::transform::threadblock::PredicatedTileAccessIterator<
+        cutlass::MatrixShape<ThreadblockShape::kK, ThreadblockShape::kN>, half_t, LayoutB, 0, ThreadMapB, AccessTypeB,
         GatherB>;
 
     // Define the threadblock-scoped multistage matrix multiply
-    using ThreadblockMma = cutlass::gemm::threadblock::MmaMultistage<typename MmaCore::Shape,
-                                                                     IteratorA,
-                                                                     typename MmaCore::SmemIteratorA,
-                                                                     MmaCore::kCacheOpA,
-                                                                     IteratorB,
-                                                                     typename MmaCore::SmemIteratorB,
-                                                                     MmaCore::kCacheOpB,
-                                                                     ElementAccumulator,
-                                                                     layout::RowMajor,
-                                                                     typename MmaCore::MmaPolicy,
-                                                                     2>;
+    using ThreadblockMma = cutlass::gemm::threadblock::MmaMultistage<typename MmaCore::Shape, IteratorA,
+        typename MmaCore::SmemIteratorA, MmaCore::kCacheOpA, IteratorB, typename MmaCore::SmemIteratorB,
+        MmaCore::kCacheOpB, ElementAccumulator, layout::RowMajor, typename MmaCore::MmaPolicy, 2>;
 };
 
-}  // namespace threadblock
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace threadblock
+} // namespace gemm
+} // namespace cutlass

--- a/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/default_mma_bf16.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/default_mma_bf16.h
@@ -4,14 +4,17 @@
 #include "cutlass_extensions/gemm/threadblock/default_dq_mma_multistage.h"
 #include "cutlass_extensions/gemm/threadblock/default_dq_mma_pipelined.h"
 
-namespace cutlass {
-namespace gemm {
-namespace threadblock {
+namespace cutlass
+{
+namespace gemm
+{
+namespace threadblock
+{
 
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Specialization for row-major output (OperatorClass TensorOp), bf16 activation & bf16 weight
-template<
+template <
     /// Layout type for A matrix operand
     typename LayoutA,
     /// Access granularity of A matrix in units of elements
@@ -38,25 +41,10 @@ template<
     bool GatherA,
     /// Gather operand B by using an index array
     bool GatherB>
-struct DefaultMma<bfloat16_t,
-                  LayoutA,
-                  kAlignmentA,
-                  bfloat16_t,
-                  LayoutB,
-                  kAlignmentB,
-                  ElementAccumulator,
-                  layout::RowMajor,
-                  arch::OpClassTensorOp,
-                  ArchTag,
-                  ThreadblockShape,
-                  WarpShape,
-                  InstructionShape,
-                  2,
-                  Operator,
-                  false,
-                  SharedMemoryClear,
-                  GatherA,
-                  GatherB> {
+struct DefaultMma<bfloat16_t, LayoutA, kAlignmentA, bfloat16_t, LayoutB, kAlignmentB, ElementAccumulator,
+    layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, 2, Operator, false,
+    SharedMemoryClear, GatherA, GatherB>
+{
 
 private:
     // Conversions only needed pre-ampere. This will trigger mma pipeline, so we convert before STS.
@@ -66,52 +54,28 @@ private:
 
 public:
     // Define the MmaCore components
-    using MmaCore = typename cutlass::gemm::threadblock::DefaultMmaCore<ThreadblockShape,
-                                                                        WarpShape,
-                                                                        InstructionShape,
-                                                                        MmaElementA,
-                                                                        LayoutA,
-                                                                        MmaElementB,
-                                                                        LayoutB,
-                                                                        ElementAccumulator,
-                                                                        layout::RowMajor,
-                                                                        arch::OpClassTensorOp,
-                                                                        2,
-                                                                        Operator>;
+    using MmaCore =
+        typename cutlass::gemm::threadblock::DefaultMmaCore<ThreadblockShape, WarpShape, InstructionShape, MmaElementA,
+            LayoutA, MmaElementB, LayoutB, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, 2, Operator>;
 
     using IteratorA = cutlass::transform::threadblock::PredicatedTileIterator<
-        cutlass::MatrixShape<MmaCore::Shape::kM, MmaCore::Shape::kK>,
-        bfloat16_t,
-        LayoutA,
-        1,
-        typename MmaCore::IteratorThreadMapA,
-        kAlignmentA,
-        GatherA>;
+        cutlass::MatrixShape<MmaCore::Shape::kM, MmaCore::Shape::kK>, bfloat16_t, LayoutA, 1,
+        typename MmaCore::IteratorThreadMapA, kAlignmentA, GatherA>;
 
     // Define iterators over tiles from the B operand
     using IteratorB = cutlass::transform::threadblock::PredicatedTileIterator<
-        cutlass::MatrixShape<MmaCore::Shape::kK, MmaCore::Shape::kN>,
-        bfloat16_t,
-        LayoutB,
-        0,
-        typename MmaCore::IteratorThreadMapB,
-        kAlignmentB,
-        GatherB>;
+        cutlass::MatrixShape<MmaCore::Shape::kK, MmaCore::Shape::kN>, bfloat16_t, LayoutB, 0,
+        typename MmaCore::IteratorThreadMapB, kAlignmentB, GatherB>;
 
     // Define the threadblock-scoped pipelined matrix multiply
-    using ThreadblockMma = cutlass::gemm::threadblock::MmaPipelined<typename MmaCore::Shape,
-                                                                    IteratorA,
-                                                                    typename MmaCore::SmemIteratorA,
-                                                                    IteratorB,
-                                                                    typename MmaCore::SmemIteratorB,
-                                                                    ElementAccumulator,
-                                                                    layout::RowMajor,
-                                                                    typename MmaCore::MmaPolicy>;
+    using ThreadblockMma = cutlass::gemm::threadblock::MmaPipelined<typename MmaCore::Shape, IteratorA,
+        typename MmaCore::SmemIteratorA, IteratorB, typename MmaCore::SmemIteratorB, ElementAccumulator,
+        layout::RowMajor, typename MmaCore::MmaPolicy>;
 };
 
 // bf16 x bf16 specialization on Ampere to use mma multistage for 2 stage. Helps avoid reg spills on
 // large tile when not enough shared mem is present to do 3+ stage
-template<
+template <
     /// Layout type for A matrix operand
     typename LayoutA,
     /// Access granularity of A matrix in units of elements
@@ -136,83 +100,41 @@ template<
     bool GatherA,
     /// Gather operand B by using an index array
     bool GatherB>
-struct DefaultMma<bfloat16_t,
-                  LayoutA,
-                  kAlignmentA,
-                  bfloat16_t,
-                  LayoutB,
-                  kAlignmentB,
-                  ElementAccumulator,
-                  layout::RowMajor,
-                  arch::OpClassTensorOp,
-                  arch::Sm80,
-                  ThreadblockShape,
-                  WarpShape,
-                  InstructionShape,
-                  2,
-                  Operator,
-                  false,
-                  SharedMemoryClear,
-                  GatherA,
-                  GatherB> {
+struct DefaultMma<bfloat16_t, LayoutA, kAlignmentA, bfloat16_t, LayoutB, kAlignmentB, ElementAccumulator,
+    layout::RowMajor, arch::OpClassTensorOp, arch::Sm80, ThreadblockShape, WarpShape, InstructionShape, 2, Operator,
+    false, SharedMemoryClear, GatherA, GatherB>
+{
 
     // Define the MmaCore components
     // 3 is used on purpose here to trigger components for mma multistage
-    using MmaCore = typename cutlass::gemm::threadblock::DefaultMmaCore<ThreadblockShape,
-                                                                        WarpShape,
-                                                                        InstructionShape,
-                                                                        bfloat16_t,
-                                                                        LayoutA,
-                                                                        bfloat16_t,
-                                                                        LayoutB,
-                                                                        ElementAccumulator,
-                                                                        layout::RowMajor,
-                                                                        arch::OpClassTensorOp,
-                                                                        3,
-                                                                        Operator>;
+    using MmaCore =
+        typename cutlass::gemm::threadblock::DefaultMmaCore<ThreadblockShape, WarpShape, InstructionShape, bfloat16_t,
+            LayoutA, bfloat16_t, LayoutB, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, 3, Operator>;
 
     // Define iterators over tiles from the A operand
-    using ThreadMapA  = typename MmaCore::IteratorThreadMapA;
+    using ThreadMapA = typename MmaCore::IteratorThreadMapA;
     using AccessTypeA = cutlass::Array<bfloat16_t, kAlignmentA>;
-    using IteratorA   = cutlass::transform::threadblock::PredicatedTileAccessIterator<
-        cutlass::MatrixShape<ThreadblockShape::kM, ThreadblockShape::kK>,
-        bfloat16_t,
-        LayoutA,
-        1,
-        ThreadMapA,
-        AccessTypeA,
-        GatherA>;
+    using IteratorA = cutlass::transform::threadblock::PredicatedTileAccessIterator<
+        cutlass::MatrixShape<ThreadblockShape::kM, ThreadblockShape::kK>, bfloat16_t, LayoutA, 1, ThreadMapA,
+        AccessTypeA, GatherA>;
 
     // Define iterators over tiles from the B operand
-    using ThreadMapB  = typename MmaCore::IteratorThreadMapB;
+    using ThreadMapB = typename MmaCore::IteratorThreadMapB;
     using AccessTypeB = cutlass::Array<bfloat16_t, kAlignmentB>;
-    using IteratorB   = cutlass::transform::threadblock::PredicatedTileAccessIterator<
-        cutlass::MatrixShape<ThreadblockShape::kK, ThreadblockShape::kN>,
-        bfloat16_t,
-        LayoutB,
-        0,
-        ThreadMapB,
-        AccessTypeB,
-        GatherB>;
+    using IteratorB = cutlass::transform::threadblock::PredicatedTileAccessIterator<
+        cutlass::MatrixShape<ThreadblockShape::kK, ThreadblockShape::kN>, bfloat16_t, LayoutB, 0, ThreadMapB,
+        AccessTypeB, GatherB>;
 
     // Define the threadblock-scoped multistage matrix multiply
-    using ThreadblockMma = cutlass::gemm::threadblock::MmaMultistage<typename MmaCore::Shape,
-                                                                     IteratorA,
-                                                                     typename MmaCore::SmemIteratorA,
-                                                                     MmaCore::kCacheOpA,
-                                                                     IteratorB,
-                                                                     typename MmaCore::SmemIteratorB,
-                                                                     MmaCore::kCacheOpB,
-                                                                     ElementAccumulator,
-                                                                     layout::RowMajor,
-                                                                     typename MmaCore::MmaPolicy,
-                                                                     2>;
+    using ThreadblockMma = cutlass::gemm::threadblock::MmaMultistage<typename MmaCore::Shape, IteratorA,
+        typename MmaCore::SmemIteratorA, MmaCore::kCacheOpA, IteratorB, typename MmaCore::SmemIteratorB,
+        MmaCore::kCacheOpB, ElementAccumulator, layout::RowMajor, typename MmaCore::MmaPolicy, 2>;
 };
 
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Specialization for row-major output (OperatorClass TensorOp), bf16 activation & int8 weight
-template<
+template <
     /// Layout type for A matrix operand
     typename LayoutA,
     /// Access granularity of A matrix in units of elements
@@ -233,43 +155,16 @@ template<
     typename InstructionShape,
     /// Operation performed by GEMM
     typename Operator>
-struct DefaultMma<cutlass::bfloat16_t,
-                  LayoutA,
-                  kAlignmentA,
-                  uint8_t,
-                  LayoutB,
-                  kAlignmentB,
-                  ElementAccumulator,
-                  layout::RowMajor,
-                  arch::OpClassTensorOp,
-                  ArchTag,
-                  ThreadblockShape,
-                  WarpShape,
-                  InstructionShape,
-                  2,
-                  Operator> {
+struct DefaultMma<cutlass::bfloat16_t, LayoutA, kAlignmentA, uint8_t, LayoutB, kAlignmentB, ElementAccumulator,
+    layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, 2, Operator>
+{
 
 private:
     static constexpr int kAlignmentScale = 128 / sizeof_bits<bfloat16_t>::value;
 
-    using Mma = DqMma<bfloat16_t,
-                      LayoutA,
-                      kAlignmentA,
-                      uint8_t,
-                      LayoutB,
-                      kAlignmentB,
-                      bfloat16_t,
-                      layout::RowMajor,
-                      kAlignmentScale,
-                      ElementAccumulator,
-                      layout::RowMajor,
-                      arch::OpClassTensorOp,
-                      ArchTag,
-                      ThreadblockShape,
-                      WarpShape,
-                      InstructionShape,
-                      2,
-                      Operator>;
+    using Mma = DqMma<bfloat16_t, LayoutA, kAlignmentA, uint8_t, LayoutB, kAlignmentB, bfloat16_t, layout::RowMajor,
+        kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+        WarpShape, InstructionShape, 2, Operator>;
 
 public:
     // Define the MmaCore components
@@ -287,7 +182,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Specialization for row-major output (OperatorClass TensorOp), bf16 activation & int4 weight
-template<
+template <
     /// Layout type for A matrix operand
     typename LayoutA,
     /// Access granularity of A matrix in units of elements
@@ -308,43 +203,16 @@ template<
     typename InstructionShape,
     /// Operation performed by GEMM
     typename Operator>
-struct DefaultMma<cutlass::bfloat16_t,
-                  LayoutA,
-                  kAlignmentA,
-                  uint4b_t,
-                  LayoutB,
-                  kAlignmentB,
-                  ElementAccumulator,
-                  layout::RowMajor,
-                  arch::OpClassTensorOp,
-                  ArchTag,
-                  ThreadblockShape,
-                  WarpShape,
-                  InstructionShape,
-                  2,
-                  Operator> {
+struct DefaultMma<cutlass::bfloat16_t, LayoutA, kAlignmentA, uint4b_t, LayoutB, kAlignmentB, ElementAccumulator,
+    layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, 2, Operator>
+{
 
 private:
     static constexpr int kAlignmentScale = 128 / sizeof_bits<bfloat16_t>::value;
 
-    using Mma = DqMma<bfloat16_t,
-                      LayoutA,
-                      kAlignmentA,
-                      uint4b_t,
-                      LayoutB,
-                      kAlignmentB,
-                      bfloat16_t,
-                      layout::RowMajor,
-                      kAlignmentScale,
-                      ElementAccumulator,
-                      layout::RowMajor,
-                      arch::OpClassTensorOp,
-                      ArchTag,
-                      ThreadblockShape,
-                      WarpShape,
-                      InstructionShape,
-                      2,
-                      Operator>;
+    using Mma = DqMma<bfloat16_t, LayoutA, kAlignmentA, uint4b_t, LayoutB, kAlignmentB, bfloat16_t, layout::RowMajor,
+        kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+        WarpShape, InstructionShape, 2, Operator>;
 
 public:
     // Define the MmaCore components
@@ -360,7 +228,7 @@ public:
     using ThreadblockMma = typename Mma::ThreadblockMma;
 };
 
-template<
+template <
     /// Layout type for A matrix operand
     typename LayoutA,
     /// Access granularity of A matrix in units of elements
@@ -385,46 +253,17 @@ template<
     int kStages,
     /// Shared memory clear option
     SharedMemoryClearOption SharedMemoryClear>
-struct DefaultMma<cutlass::bfloat16_t,
-                  LayoutA,
-                  kAlignmentA,
-                  uint8_t,
-                  LayoutB,
-                  kAlignmentB,
-                  ElementAccumulator,
-                  layout::RowMajor,
-                  arch::OpClassTensorOp,
-                  ArchTag,
-                  ThreadblockShape,
-                  WarpShape,
-                  InstructionShape,
-                  kStages,
-                  Operator,
-                  false,
-                  SharedMemoryClear> {
+struct DefaultMma<cutlass::bfloat16_t, LayoutA, kAlignmentA, uint8_t, LayoutB, kAlignmentB, ElementAccumulator,
+    layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, kStages, Operator,
+    false, SharedMemoryClear>
+{
 
 private:
     static constexpr int kAlignmentScale = 128 / sizeof_bits<bfloat16_t>::value;
 
-    using Mma = DqMma<bfloat16_t,
-                      LayoutA,
-                      kAlignmentA,
-                      uint8_t,
-                      LayoutB,
-                      kAlignmentB,
-                      bfloat16_t,
-                      layout::RowMajor,
-                      kAlignmentScale,
-                      ElementAccumulator,
-                      layout::RowMajor,
-                      arch::OpClassTensorOp,
-                      ArchTag,
-                      ThreadblockShape,
-                      WarpShape,
-                      InstructionShape,
-                      kStages,
-                      Operator,
-                      SharedMemoryClear>;
+    using Mma = DqMma<bfloat16_t, LayoutA, kAlignmentA, uint8_t, LayoutB, kAlignmentB, bfloat16_t, layout::RowMajor,
+        kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+        WarpShape, InstructionShape, kStages, Operator, SharedMemoryClear>;
 
 public:
     // Define the MmaCore components
@@ -442,7 +281,7 @@ public:
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Specialization for row-major output (OperatorClass TensorOp), fp16 activation & int4 weight
-template<
+template <
     /// Layout type for A matrix operand
     typename LayoutA,
     /// Access granularity of A matrix in units of elements
@@ -467,46 +306,17 @@ template<
     int kStages,
     /// Shared memory clear option
     SharedMemoryClearOption SharedMemoryClear>
-struct DefaultMma<cutlass::bfloat16_t,
-                  LayoutA,
-                  kAlignmentA,
-                  uint4b_t,
-                  LayoutB,
-                  kAlignmentB,
-                  ElementAccumulator,
-                  layout::RowMajor,
-                  arch::OpClassTensorOp,
-                  ArchTag,
-                  ThreadblockShape,
-                  WarpShape,
-                  InstructionShape,
-                  kStages,
-                  Operator,
-                  false,
-                  SharedMemoryClear> {
+struct DefaultMma<cutlass::bfloat16_t, LayoutA, kAlignmentA, uint4b_t, LayoutB, kAlignmentB, ElementAccumulator,
+    layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape, WarpShape, InstructionShape, kStages, Operator,
+    false, SharedMemoryClear>
+{
 
 private:
     static constexpr int kAlignmentScale = 128 / sizeof_bits<bfloat16_t>::value;
 
-    using Mma = DqMma<bfloat16_t,
-                      LayoutA,
-                      kAlignmentA,
-                      uint4b_t,
-                      LayoutB,
-                      kAlignmentB,
-                      bfloat16_t,
-                      layout::RowMajor,
-                      kAlignmentScale,
-                      ElementAccumulator,
-                      layout::RowMajor,
-                      arch::OpClassTensorOp,
-                      ArchTag,
-                      ThreadblockShape,
-                      WarpShape,
-                      InstructionShape,
-                      kStages,
-                      Operator,
-                      SharedMemoryClear>;
+    using Mma = DqMma<bfloat16_t, LayoutA, kAlignmentA, uint4b_t, LayoutB, kAlignmentB, bfloat16_t, layout::RowMajor,
+        kAlignmentScale, ElementAccumulator, layout::RowMajor, arch::OpClassTensorOp, ArchTag, ThreadblockShape,
+        WarpShape, InstructionShape, kStages, Operator, SharedMemoryClear>;
 
 public:
     // Define the MmaCore components
@@ -522,6 +332,6 @@ public:
     using ThreadblockMma = typename Mma::ThreadblockMma;
 };
 
-}  // namespace threadblock
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace threadblock
+} // namespace gemm
+} // namespace cutlass

--- a/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/dq_mma_base.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/dq_mma_base.h
@@ -45,39 +45,37 @@
 
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace cutlass {
-namespace gemm {
-namespace threadblock {
+namespace cutlass
+{
+namespace gemm
+{
+namespace threadblock
+{
 
 ////////////////////////////////////////////////////////////////////////////////
 // SFINAE trick so I can keep the same loop code for Volta and dispatch to the
 // correct warp level mma. On volta, all data is stored to shared memory as FP16.
-template<typename WarpMma, int kExpansionFactor = 1>
-CUTLASS_DEVICE void run_warp_mma(WarpMma&                           warp_mma,
-                                 typename WarpMma::FragmentC&       D,
-                                 typename WarpMma::FragmentA const& A,
-                                 typename WarpMma::FragmentB const& B,
-                                 typename WarpMma::FragmentC const& C,
-                                 const int                          warp_tileB_k_offset)
+template <typename WarpMma, int kExpansionFactor = 1>
+CUTLASS_DEVICE void run_warp_mma(WarpMma& warp_mma, typename WarpMma::FragmentC& D,
+    typename WarpMma::FragmentA const& A, typename WarpMma::FragmentB const& B, typename WarpMma::FragmentC const& C,
+    const int warp_tileB_k_offset)
 {
     warp_mma(D, A, B, C);
 }
 
-template<typename WarpMma, int kExpansionFactor = WarpMma::kExpansionFactor>
-CUTLASS_DEVICE void run_warp_mma(WarpMma&                                      warp_mma,
-                                 typename WarpMma::FragmentC&                  D,
-                                 typename WarpMma::TransformedFragmentA const& A,
-                                 typename WarpMma::TransformedFragmentB const& B,
-                                 typename WarpMma::FragmentC const&            C,
-                                 const int                                     warp_tileB_k_offset)
+template <typename WarpMma, int kExpansionFactor = WarpMma::kExpansionFactor>
+CUTLASS_DEVICE void run_warp_mma(WarpMma& warp_mma, typename WarpMma::FragmentC& D,
+    typename WarpMma::TransformedFragmentA const& A, typename WarpMma::TransformedFragmentB const& B,
+    typename WarpMma::FragmentC const& C, const int warp_tileB_k_offset)
 {
     warp_mma(D, A, B, C, warp_tileB_k_offset);
 }
+
 ////////////////////////////////////////////////////////////////////////////////
 
 /// Structure to compute the matrix product targeting CUDA cores and SIMT math
 /// instructions.
-template<
+template <
     /// Size of the Gemm problem - concept: gemm::GemmShape<>
     typename Shape_,
     /// Policy describing tuning details (concept: MmaPolicy)
@@ -88,7 +86,8 @@ template<
     int Stages,
     /// Used for partial specialization
     typename Enable = bool>
-class DqMmaBase {
+class DqMmaBase
+{
 public:
     ///< Size of the Gemm problem - concept: gemm::GemmShape<>
     using Shape = Shape_;
@@ -116,8 +115,8 @@ public:
     /// Number of warp-level GEMM oeprations
     static int const kWarpGemmIterations = (WarpGemm::kK / Operator::Policy::MmaShape::kK);
 
-    static constexpr int kNumKIterationsPerWarpBLoad =
-        Operator::IteratorB::InstructionShape::kRow / Operator::InstructionShape::kK;
+    static constexpr int kNumKIterationsPerWarpBLoad
+        = Operator::IteratorB::InstructionShape::kRow / Operator::InstructionShape::kK;
 
     static_assert(!(kWarpGemmIterations % kNumKIterationsPerWarpBLoad), "");
     static constexpr int kWarpGemmIterationsForB = kWarpGemmIterations / kNumKIterationsPerWarpBLoad;
@@ -136,19 +135,20 @@ public:
     //
 
     /// Shared storage object needed by threadblock-scoped GEMM
-    class SharedStorage {
+    class SharedStorage
+    {
     public:
         //
         // Type definitions
         //
 
         /// Shape of the A matrix operand in shared memory
-        using ShapeA =
-            MatrixShape<Shape::kM + Policy::SmemPaddingA::kRow, Shape::kK * kStages + Policy::SmemPaddingA::kColumn>;
+        using ShapeA
+            = MatrixShape<Shape::kM + Policy::SmemPaddingA::kRow, Shape::kK * kStages + Policy::SmemPaddingA::kColumn>;
 
         /// Shape of the B matrix operand in shared memory
-        using ShapeB =
-            MatrixShape<Shape::kK * kStages + Policy::SmemPaddingB::kRow, Shape::kN + Policy::SmemPaddingB::kColumn>;
+        using ShapeB
+            = MatrixShape<Shape::kK * kStages + Policy::SmemPaddingB::kRow, Shape::kN + Policy::SmemPaddingB::kColumn>;
 
     public:
         //
@@ -220,17 +220,17 @@ public:
         ///< ID of warp
         int warp_idx,
         ///< ID of each thread within a warp
-        int lane_idx):
-        warp_tile_iterator_A_(shared_storage.operand_A_ref(), lane_idx),
-        warp_tile_iterator_B_(shared_storage.operand_B_ref(), lane_idx)
+        int lane_idx)
+        : warp_tile_iterator_A_(shared_storage.operand_A_ref(), lane_idx)
+        , warp_tile_iterator_B_(shared_storage.operand_B_ref(), lane_idx)
     {
     }
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-}  // namespace threadblock
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace threadblock
+} // namespace gemm
+} // namespace cutlass
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/dq_mma_pipelined.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/threadblock/dq_mma_pipelined.h
@@ -53,14 +53,17 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace cutlass {
-namespace gemm {
-namespace threadblock {
+namespace cutlass
+{
+namespace gemm
+{
+namespace threadblock
+{
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Structure to compute the matrix product targeting CUDA cores and SIMT math instructions.
-template<
+template <
     /// Size of the Gemm problem - concept: gemm::GemmShape<>
     typename Shape_,
     /// Iterates over tiles of A operand in global memory
@@ -91,24 +94,25 @@ template<
     typename TransformBAfterLDS_,
     /// Used for partial specialization
     typename Enable = bool>
-class DqMmaPipelined: public DqMmaBase<Shape_, Policy_, typename SmemIteratorScale_::Element, 2> {
+class DqMmaPipelined : public DqMmaBase<Shape_, Policy_, typename SmemIteratorScale_::Element, 2>
+{
 public:
     ///< Base class
     using Base = DqMmaBase<Shape_, Policy_, typename SmemIteratorScale_::Element, 2>;
 
-    using Shape     = Shape_;      ///< Size of the Gemm problem - concept: gemm::GemmShape<>
-    using IteratorA = IteratorA_;  ///< Iterates over tiles of A operand in global memory
-    using IteratorB = IteratorB_;  ///< Iterates over tiles of B operand in global memory
-    using ElementC  = ElementC_;   ///< Data type of accumulator matrix
-    using LayoutC   = LayoutC_;    ///< Layout of accumulator matrix
-    using Policy    = Policy_;     ///< Policy describing tuning details
+    using Shape = Shape_;         ///< Size of the Gemm problem - concept: gemm::GemmShape<>
+    using IteratorA = IteratorA_; ///< Iterates over tiles of A operand in global memory
+    using IteratorB = IteratorB_; ///< Iterates over tiles of B operand in global memory
+    using ElementC = ElementC_;   ///< Data type of accumulator matrix
+    using LayoutC = LayoutC_;     ///< Layout of accumulator matrix
+    using Policy = Policy_;       ///< Policy describing tuning details
 
     using IteratorScale = IteratorScale_;
-    using ElementScale  = typename IteratorScale::Element;
-    using LayoutScale   = typename IteratorScale::Layout;
+    using ElementScale = typename IteratorScale::Element;
+    using LayoutScale = typename IteratorScale::Layout;
 
-    using SmemIteratorA     = SmemIteratorA_;
-    using SmemIteratorB     = SmemIteratorB_;
+    using SmemIteratorA = SmemIteratorA_;
+    using SmemIteratorB = SmemIteratorB_;
     using SmemIteratorScale = SmemIteratorScale_;
 
     using TransformBAfterLDG = TransformBAfterLDG_;
@@ -136,12 +140,8 @@ public:
     /// Obtain the arch tag from the warp-level operator
     using ArchTag = typename Policy::Operator::ArchTag;
 
-    using Dequantizer = warp::MmaTensorOpDequantizer<Operator,
-                                                     typename Base::WarpGemm,
-                                                     Operand::kB,
-                                                     typename SmemIteratorScale::Fragment::Element,
-                                                     LayoutScale,
-                                                     32>;
+    using Dequantizer = warp::MmaTensorOpDequantizer<Operator, typename Base::WarpGemm, Operand::kB,
+        typename SmemIteratorScale::Fragment::Element, LayoutScale, 32>;
 
     /// Complex transform on A operand
     static ComplexTransform const kTransformA = Operator::kTransformA;
@@ -157,13 +157,13 @@ private:
     using WarpFragmentB = typename Operator::FragmentB;
     Dequantizer warp_dequantizer_;
 
-    using ElementB          = typename IteratorB::Element;
+    using ElementB = typename IteratorB::Element;
     using LayoutDetailsForB = kernel::LayoutDetailsB<ElementB, ArchTag>;
 
-    static constexpr bool RequiresTileInterleave =
-        layout::IsColumnMajorTileInterleave<typename LayoutDetailsForB::Layout>::value;
+    static constexpr bool RequiresTileInterleave
+        = layout::IsColumnMajorTileInterleave<typename LayoutDetailsForB::Layout>::value;
     static_assert(!RequiresTileInterleave || (RequiresTileInterleave && (Shape::kK == LayoutDetailsForB::ThreadblockK)),
-                  "Layout K must match threadblockK");
+        "Layout K must match threadblockK");
 
 protected:
     /// Iterator to write threadblock-scoped tile of A operand to shared memory
@@ -179,18 +179,17 @@ public:
     /// Construct from tensor references
     CUTLASS_DEVICE
     DqMmaPipelined(typename Base::SharedStorage&
-                       shared_storage,  ///< Shared storage needed for internal use by threadblock-scoped GEMM
-                   int thread_idx,      ///< ID within the threadblock
-                   int warp_idx,        ///< ID of warp
-                   int lane_idx         ///< ID of each thread within a warp
-                   ):
-        Base(shared_storage, thread_idx, warp_idx, lane_idx),
-        warp_dequantizer_({shared_storage.operand_scale.data(), LayoutScale(Shape::kN)},
-                          (warp_idx % (Base::WarpCount::kM * Base::WarpCount::kN)) / Base::WarpCount::kM,
-                          lane_idx),
-        smem_iterator_A_(shared_storage.operand_A_ref(), thread_idx),
-        smem_iterator_B_(shared_storage.operand_B_ref(), thread_idx),
-        smem_iterator_scale_(LayoutScale(Shape::kN), shared_storage.operand_scale.data(), {1, Shape::kN}, thread_idx)
+                       shared_storage, ///< Shared storage needed for internal use by threadblock-scoped GEMM
+        int thread_idx,                ///< ID within the threadblock
+        int warp_idx,                  ///< ID of warp
+        int lane_idx                   ///< ID of each thread within a warp
+        )
+        : Base(shared_storage, thread_idx, warp_idx, lane_idx)
+        , warp_dequantizer_({shared_storage.operand_scale.data(), LayoutScale(Shape::kN)},
+              (warp_idx % (Base::WarpCount::kM * Base::WarpCount::kN)) / Base::WarpCount::kM, lane_idx)
+        , smem_iterator_A_(shared_storage.operand_A_ref(), thread_idx)
+        , smem_iterator_B_(shared_storage.operand_B_ref(), thread_idx)
+        , smem_iterator_scale_(LayoutScale(Shape::kN), shared_storage.operand_scale.data(), {1, Shape::kN}, thread_idx)
     {
 
         // Compute warp location within threadblock tile by mapping the warp_id to
@@ -200,7 +199,7 @@ public:
         //   _k: the warp's position within the threadblock along the K dimension
 
         int warp_idx_mn = warp_idx % (Base::WarpCount::kM * Base::WarpCount::kN);
-        int warp_idx_k  = warp_idx / (Base::WarpCount::kM * Base::WarpCount::kN);
+        int warp_idx_k = warp_idx / (Base::WarpCount::kM * Base::WarpCount::kN);
 
         int warp_idx_m = warp_idx_mn % Base::WarpCount::kM;
         int warp_idx_n = warp_idx_mn / Base::WarpCount::kM;
@@ -212,13 +211,13 @@ public:
 
     /// Perform a threadblock-scoped matrix multiply-accumulate
     CUTLASS_DEVICE
-    void operator()(int              gemm_k_iterations,  ///< number of iterations of the mainloop
-                    FragmentC&       accum,              ///< destination accumulator tile
-                    IteratorA        iterator_A,         ///< iterator over A operand in global memory
-                    IteratorB        iterator_B,         ///< iterator over B operand in global memory
-                    IteratorScale    iterator_scale,     ///< iterator over scale operand in global memory
-                    FragmentC const& src_accum)
-    {  ///< source accumulator tile
+    void operator()(int gemm_k_iterations, ///< number of iterations of the mainloop
+        FragmentC& accum,                  ///< destination accumulator tile
+        IteratorA iterator_A,              ///< iterator over A operand in global memory
+        IteratorB iterator_B,              ///< iterator over B operand in global memory
+        IteratorScale iterator_scale,      ///< iterator over scale operand in global memory
+        FragmentC const& src_accum)
+    { ///< source accumulator tile
 
         //
         // Prologue
@@ -226,23 +225,22 @@ public:
         TransformBAfterLDG ldg_converter;
         TransformBAfterLDS lds_converter;
 
-        using TransformA =
-            NumericArrayConverter<typename WarpFragmentA::Element, typename FragmentA::Element, FragmentA::kElements>;
+        using TransformA
+            = NumericArrayConverter<typename WarpFragmentA::Element, typename FragmentA::Element, FragmentA::kElements>;
 
         using TransformScale = NumericArrayConverter<typename SmemIteratorScale::Fragment::Element,
-                                                     typename FragmentScale::Element,
-                                                     FragmentScale::kElements>;
+            typename FragmentScale::Element, FragmentScale::kElements>;
 
         // These transforms are mainly to handle when we have bfloat activations and weights in GMEM and want
         // to issue HMMA on architectures older than Ampere. We will convert to FP16 before STS.
-        TransformA     transformA;
+        TransformA transformA;
         TransformScale transformScale;
 
         // Perform accumulation in the 'd' output operand
         accum = src_accum;
 
-        FragmentA     tb_frag_A;
-        FragmentB     tb_frag_B;
+        FragmentA tb_frag_A;
+        FragmentB tb_frag_B;
         FragmentScale tb_frag_scales;
 
         using WarpFragmentScale = typename Dequantizer::FragmentScale;
@@ -301,18 +299,21 @@ public:
 
         // Note: The main loop does not support Base::kWarpGemmIterations == 2.
         CUTLASS_GEMM_LOOP
-        for (; gemm_k_iterations > 0; --gemm_k_iterations) {
+        for (; gemm_k_iterations > 0; --gemm_k_iterations)
+        {
             //
             // Loop over GEMM K dimension
             //
 
             CUTLASS_PRAGMA_UNROLL
-            for (int warp_mma_k = 0; warp_mma_k < Base::kWarpGemmIterations; ++warp_mma_k) {
+            for (int warp_mma_k = 0; warp_mma_k < Base::kWarpGemmIterations; ++warp_mma_k)
+            {
 
                 // Load warp-level tiles from shared memory, wrapping to k offset if this is the last group
                 // as the case may be.
 
-                if (warp_mma_k == Base::kWarpGemmIterations - 1) {
+                if (warp_mma_k == Base::kWarpGemmIterations - 1)
+                {
 
                     // Write fragments to shared memory
                     this->smem_iterator_A_.store(transformA(tb_frag_A));
@@ -325,11 +326,13 @@ public:
                     ++this->smem_iterator_B_;
 
                     // Add negative offsets to return iterators to the 'start' of the circular buffer in shared memory
-                    if (smem_write_stage_idx == 1) {
+                    if (smem_write_stage_idx == 1)
+                    {
                         this->smem_iterator_A_.add_tile_offset({0, -Base::kStages});
                         this->smem_iterator_B_.add_tile_offset({-Base::kStages, 0});
                     }
-                    else {
+                    else
+                    {
                         this->warp_tile_iterator_A_.add_tile_offset(
                             {0, -Base::kStages * Policy::kPartitionsK * Base::kWarpGemmIterations});
                         this->warp_tile_iterator_B_.add_tile_offset(
@@ -344,16 +347,18 @@ public:
                 ++this->warp_tile_iterator_A_;
 
                 const int warp_tileB_k_compute_offset = warp_mma_k % Base::kNumKIterationsPerWarpBLoad;
-                const int warp_tileB_k_load_offset    = warp_mma_k / Base::kNumKIterationsPerWarpBLoad;
+                const int warp_tileB_k_load_offset = warp_mma_k / Base::kNumKIterationsPerWarpBLoad;
                 // We are just about to finish computing on a fragment of B, so initiate the load for the next fragment.
-                if (warp_tileB_k_compute_offset == Base::kNumKIterationsPerWarpBLoad - 1) {
-                    this->warp_tile_iterator_B_.set_kgroup_index((warp_tileB_k_load_offset + 1)
-                                                                 % Base::kWarpGemmIterationsForB);
+                if (warp_tileB_k_compute_offset == Base::kNumKIterationsPerWarpBLoad - 1)
+                {
+                    this->warp_tile_iterator_B_.set_kgroup_index(
+                        (warp_tileB_k_load_offset + 1) % Base::kWarpGemmIterationsForB);
                     this->warp_tile_iterator_B_.load(warp_frag_B[(warp_tileB_k_load_offset + 1) % 2]);
                     ++this->warp_tile_iterator_B_;
                 }
 
-                if (warp_mma_k == 0) {
+                if (warp_mma_k == 0)
+                {
 
                     iterator_A.load(tb_frag_A);
                     iterator_B.load(tb_frag_B);
@@ -366,8 +371,8 @@ public:
                     iterator_B.clear_mask(gemm_k_iterations <= 2);
                 }
 
-                typename TransformBAfterLDS::result_type converted_frag_B =
-                    lds_converter(warp_frag_B[warp_tileB_k_load_offset % 2]);
+                typename TransformBAfterLDS::result_type converted_frag_B
+                    = lds_converter(warp_frag_B[warp_tileB_k_load_offset % 2]);
                 warp_dequantizer_.dequantize(converted_frag_B, warp_frag_scales);
                 run_warp_mma(
                     warp_mma, accum, warp_frag_A[warp_mma_k % 2], converted_frag_B, accum, warp_tileB_k_compute_offset);
@@ -378,8 +383,8 @@ public:
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-}  // namespace threadblock
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace threadblock
+} // namespace gemm
+} // namespace cutlass
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cutlass_extensions/include/cutlass_extensions/gemm/warp/default_mma_tensor_op.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/warp/default_mma_tensor_op.h
@@ -41,14 +41,17 @@
 #include "cutlass_extensions/arch/mma.h"
 #include "cutlass_extensions/gemm/warp/mma_tensorop_compute_B_with_f16.h"
 
-namespace cutlass {
-namespace gemm {
-namespace warp {
+namespace cutlass
+{
+namespace gemm
+{
+namespace warp
+{
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
 /// Partial specialization for m-by-n-by-kgroup
-template<
+template <
     /// Shape of one matrix production operation (concept: GemmShape)
     typename WarpShape_,
     /// Shape of one matrix production operation (concept: GemmShape)
@@ -70,17 +73,9 @@ template<
     /// Store the accumulators in row major or column major.  Row major is used
     /// when output layout is interleaved.
     bool AccumulatorsInRowMajor>
-struct DefaultMmaTensorOp<WarpShape_,
-                          InstructionShape_,
-                          ElementA,
-                          LayoutA,
-                          ElementB,
-                          LayoutB,
-                          ElementC,
-                          LayoutC,
-                          arch::OpMultiplyAddDequantizeInterleavedBToA,
-                          PartitionsK,
-                          AccumulatorsInRowMajor> {
+struct DefaultMmaTensorOp<WarpShape_, InstructionShape_, ElementA, LayoutA, ElementB, LayoutB, ElementC, LayoutC,
+    arch::OpMultiplyAddDequantizeInterleavedBToA, PartitionsK, AccumulatorsInRowMajor>
+{
 
 private:
     // Shape for computing the FP16s
@@ -93,35 +88,20 @@ private:
     using LoadInstructionShape = GemmShape<InstructionShape_::kM, InstructionShape_::kN, LoadInstructionK>;
 
 public:
-    using Policy = cutlass::gemm::warp::MmaTensorOpPolicy<cutlass::arch::Mma<InstructionShape_,
-                                                                             32,
-                                                                             ElementA,
-                                                                             cutlass::layout::RowMajor,
-                                                                             ElementA,
-                                                                             cutlass::layout::ColumnMajor,
-                                                                             ElementC,
-                                                                             cutlass::layout::RowMajor,
-                                                                             arch::OpMultiplyAdd>,
-                                                          cutlass::MatrixShape<1, 1>>;
+    using Policy = cutlass::gemm::warp::MmaTensorOpPolicy<
+        cutlass::arch::Mma<InstructionShape_, 32, ElementA, cutlass::layout::RowMajor, ElementA,
+            cutlass::layout::ColumnMajor, ElementC, cutlass::layout::RowMajor, arch::OpMultiplyAdd>,
+        cutlass::MatrixShape<1, 1>>;
 
     // Define the warp-level tensor op
-    using Type = cutlass::gemm::warp::MmaTensorOpComputeBWithF16<WarpShape_,
-                                                                 ElementA,
-                                                                 LayoutA,
-                                                                 ElementB,
-                                                                 LayoutB,
-                                                                 ElementC,
-                                                                 LayoutC,
-                                                                 Policy,
-                                                                 LoadInstructionShape,
-                                                                 PartitionsK,
-                                                                 AccumulatorsInRowMajor>;
+    using Type = cutlass::gemm::warp::MmaTensorOpComputeBWithF16<WarpShape_, ElementA, LayoutA, ElementB, LayoutB,
+        ElementC, LayoutC, Policy, LoadInstructionShape, PartitionsK, AccumulatorsInRowMajor>;
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-}  // namespace warp
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace warp
+} // namespace gemm
+} // namespace cutlass
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cutlass_extensions/include/cutlass_extensions/gemm/warp/mma_tensorop_compute_B_with_f16.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/warp/mma_tensorop_compute_B_with_f16.h
@@ -57,13 +57,16 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace cutlass {
-namespace gemm {
-namespace warp {
+namespace cutlass
+{
+namespace gemm
+{
+namespace warp
+{
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 /// Structure to compute the matrix product targeting CUDA cores and SIMT math instructions.
-template<
+template <
     /// Size of the Gemm problem - concept: gemm::GemmShape<>
     typename Shape_,
     /// Data type of A elements
@@ -89,7 +92,8 @@ template<
     bool AccumulatorsInRowMajor = false,
     /// Used for partial specialization
     typename Enable = bool>
-class MmaTensorOpComputeBWithF16 {
+class MmaTensorOpComputeBWithF16
+{
 public:
     /// Shape of warp-level matrix operation (concept: GemmShape)
     using Shape = Shape_;
@@ -124,15 +128,15 @@ public:
     /// Architecture tag from underlying instruction
     using ArchTag = typename ArchMmaOperator::ArchTag;
     static_assert((platform::is_same<typename ArchMmaOperator::ElementA, half_t>::value
-                   && platform::is_same<typename ArchMmaOperator::ElementB, half_t>::value)
-                      || (platform::is_same<typename ArchMmaOperator::ElementA, bfloat16_t>::value
-                          && platform::is_same<typename ArchMmaOperator::ElementB, bfloat16_t>::value
-                          && ArchTag::kMinComputeCapability >= 80),
-                  "MmaTensorOpCvtBToA only supports underlying HMMA");
+                      && platform::is_same<typename ArchMmaOperator::ElementB, half_t>::value)
+            || (platform::is_same<typename ArchMmaOperator::ElementA, bfloat16_t>::value
+                && platform::is_same<typename ArchMmaOperator::ElementB, bfloat16_t>::value
+                && ArchTag::kMinComputeCapability >= 80),
+        "MmaTensorOpCvtBToA only supports underlying HMMA");
 
     static_assert(platform::is_same<ElementA, half_t>::value
-                      || (platform::is_same<ElementA, bfloat16_t>::value && ArchTag::kMinComputeCapability >= 80),
-                  "MmaTensorOpCvtBToA only supports Fp16 A or Bf16 A on Ampere+");
+            || (platform::is_same<ElementA, bfloat16_t>::value && ArchTag::kMinComputeCapability >= 80),
+        "MmaTensorOpCvtBToA only supports Fp16 A or Bf16 A on Ampere+");
 
     /// Indicates class of matrix operator
     using OperatorClass = arch::OpClassTensorOp;
@@ -143,10 +147,10 @@ public:
     /// Instruction shape to override shared memory iterators with
     using SharedMemoryInstructionShape = SharedMemoryInstructionShape_;
 
-    static_assert(SharedMemoryInstructionShape::kM == InstructionShape::kM,
-                  "M dimension of compute instruction must match load");
-    static_assert(SharedMemoryInstructionShape::kN == InstructionShape::kN,
-                  "N dimension of compute instruction must match load");
+    static_assert(
+        SharedMemoryInstructionShape::kM == InstructionShape::kM, "M dimension of compute instruction must match load");
+    static_assert(
+        SharedMemoryInstructionShape::kN == InstructionShape::kN, "N dimension of compute instruction must match load");
 
     static constexpr int kExpansionFactor = SharedMemoryInstructionShape::kK / InstructionShape::kK;
 
@@ -166,14 +170,9 @@ public:
 
 public:
     /// Iterates over the A operand in memory
-    using IteratorA = MmaTensorOpMultiplicandTileIterator<MatrixShape<Shape::kM, Shape::kK>,
-                                                          Operand::kA,
-                                                          ElementA,
-                                                          LayoutA,
-                                                          MatrixShape<InstructionShape::kM, InstructionShape::kK>,
-                                                          Policy::OpDelta::kRow,
-                                                          kThreadCount,
-                                                          kPartitionsK>;
+    using IteratorA
+        = MmaTensorOpMultiplicandTileIterator<MatrixShape<Shape::kM, Shape::kK>, Operand::kA, ElementA, LayoutA,
+            MatrixShape<InstructionShape::kM, InstructionShape::kK>, Policy::OpDelta::kRow, kThreadCount, kPartitionsK>;
 
     /// Storage for A tile
     using FragmentA = typename IteratorA::Fragment;
@@ -182,15 +181,9 @@ public:
     using TransformedFragmentA = Array<typename ArchMmaOperator::ElementA, FragmentA::kElements>;
 
     /// Iterates over the B operand in memory
-    using IteratorB =
-        MmaTensorOpMultiplicandTileIterator<MatrixShape<Shape::kK, Shape::kN>,
-                                            Operand::kB,
-                                            ElementB,
-                                            LayoutB,
-                                            MatrixShape<SharedMemoryInstructionShape::kK, InstructionShape::kN>,
-                                            Policy::OpDelta::kRow,
-                                            kThreadCount,
-                                            kPartitionsK>;
+    using IteratorB = MmaTensorOpMultiplicandTileIterator<MatrixShape<Shape::kK, Shape::kN>, Operand::kB, ElementB,
+        LayoutB, MatrixShape<SharedMemoryInstructionShape::kK, InstructionShape::kN>, Policy::OpDelta::kRow,
+        kThreadCount, kPartitionsK>;
 
     /// Storage for B tile
     using FragmentB = typename IteratorB::Fragment;
@@ -199,18 +192,15 @@ public:
     using TransformedFragmentB = Array<typename ArchMmaOperator::ElementB, FragmentB::kElements>;
 
     /// Iterates over the C operand in memory
-    using IteratorC = MmaTensorOpAccumulatorTileIterator<MatrixShape<Shape::kM, Shape::kN>,
-                                                         ElementC,
-                                                         LayoutC,
-                                                         typename ArchMmaOperator::Shape,
-                                                         typename Policy::OpDelta>;
+    using IteratorC = MmaTensorOpAccumulatorTileIterator<MatrixShape<Shape::kM, Shape::kN>, ElementC, LayoutC,
+        typename ArchMmaOperator::Shape, typename Policy::OpDelta>;
 
     /// Storage for C tile
     using FragmentC = typename IteratorC::Fragment;
 
     /// Number of mma operations performed
     using MmaIterations = MatrixShape<(Shape::kM + ArchMmaOperator::Shape::kM - 1) / ArchMmaOperator::Shape::kM,
-                                      (Shape::kN + ArchMmaOperator::Shape::kN - 1) / ArchMmaOperator::Shape::kN>;
+        (Shape::kN + ArchMmaOperator::Shape::kN - 1) / ArchMmaOperator::Shape::kN>;
 
 public:
     /// Underlying matrix multiply operator (concept: arch::Mma)
@@ -227,11 +217,8 @@ public:
 
     /// Performs a warp-level matrix multiply-accumulate operation
     CUTLASS_DEVICE
-    void operator()(FragmentC&                  D,
-                    TransformedFragmentA const& A,
-                    TransformedFragmentB const& B,
-                    FragmentC const&            C,
-                    const int                   warp_tileB_k_offset) const
+    void operator()(FragmentC& D, TransformedFragmentA const& A, TransformedFragmentB const& B, FragmentC const& C,
+        const int warp_tileB_k_offset) const
     {
 
         using MmaOperandA = typename ArchMmaOperator::FragmentA;
@@ -240,35 +227,36 @@ public:
 
         static_assert(
             TransformedFragmentB::kElements == MmaOperandB::kElements * kExpansionFactor * MmaIterations::kColumn,
-            "Each thread should have a pack of mma registers for each column iteration AND for the expanded K dim of B");
+            "Each thread should have a pack of mma registers for each column iteration AND for the expanded K dim of "
+            "B");
 
         D = C;
 
         MmaOperandA const* ptr_A = reinterpret_cast<MmaOperandA const*>(&A);
         MmaOperandB const* ptr_B = reinterpret_cast<MmaOperandB const*>(&B);
-        MmaOperandC*       ptr_D = reinterpret_cast<MmaOperandC*>(&D);
+        MmaOperandC* ptr_D = reinterpret_cast<MmaOperandC*>(&D);
 
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800)
         // Serpentine visitation order maximizing reuse of Rb
         CUTLASS_PRAGMA_UNROLL
-        for (int n = 0; n < MmaIterations::kColumn; ++n) {
+        for (int n = 0; n < MmaIterations::kColumn; ++n)
+        {
 
             CUTLASS_PRAGMA_UNROLL
-            for (int m = 0; m < MmaIterations::kRow; ++m) {
+            for (int m = 0; m < MmaIterations::kRow; ++m)
+            {
 
                 int m_serpentine = ((n % 2) ? (MmaIterations::kRow - 1 - m) : m);
 
                 int n_offsetB = warp_tileB_k_offset + kExpansionFactor * n;
-                if (AccumulatorsInRowMajor) {  // matrix B is reordered
-                    mma(ptr_D[n + m_serpentine * MmaIterations::kColumn],
-                        ptr_A[m_serpentine],
-                        ptr_B[n_offsetB],
+                if (AccumulatorsInRowMajor)
+                { // matrix B is reordered
+                    mma(ptr_D[n + m_serpentine * MmaIterations::kColumn], ptr_A[m_serpentine], ptr_B[n_offsetB],
                         ptr_D[n + m_serpentine * MmaIterations::kColumn]);
                 }
-                else {
-                    mma(ptr_D[m_serpentine + n * MmaIterations::kRow],
-                        ptr_A[m_serpentine],
-                        ptr_B[n_offsetB],
+                else
+                {
+                    mma(ptr_D[m_serpentine + n * MmaIterations::kRow], ptr_A[m_serpentine], ptr_B[n_offsetB],
                         ptr_D[m_serpentine + n * MmaIterations::kRow]);
                 }
             }
@@ -276,24 +264,24 @@ public:
 #elif defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
         // Serpentine visitation order maximizing reuse of Ra
         CUTLASS_PRAGMA_UNROLL
-        for (int m = 0; m < MmaIterations::kRow; ++m) {
+        for (int m = 0; m < MmaIterations::kRow; ++m)
+        {
 
             CUTLASS_PRAGMA_UNROLL
-            for (int n = 0; n < MmaIterations::kColumn; ++n) {
+            for (int n = 0; n < MmaIterations::kColumn; ++n)
+            {
 
                 int n_serpentine = ((m % 2) ? (MmaIterations::kColumn - 1 - n) : n);
 
                 int n_serpentine_offsetB = warp_tileB_k_offset + kExpansionFactor * n_serpentine;
-                if (AccumulatorsInRowMajor) {  // matrix B is reordered
-                    mma(ptr_D[n_serpentine + m * MmaIterations::kColumn],
-                        ptr_A[m],
-                        ptr_B[n_serpentine_offsetB],
+                if (AccumulatorsInRowMajor)
+                { // matrix B is reordered
+                    mma(ptr_D[n_serpentine + m * MmaIterations::kColumn], ptr_A[m], ptr_B[n_serpentine_offsetB],
                         ptr_D[n_serpentine + m * MmaIterations::kColumn]);
                 }
-                else {
-                    mma(ptr_D[m + n_serpentine * MmaIterations::kRow],
-                        ptr_A[m],
-                        ptr_B[n_serpentine_offsetB],
+                else
+                {
+                    mma(ptr_D[m + n_serpentine * MmaIterations::kRow], ptr_A[m], ptr_B[n_serpentine_offsetB],
                         ptr_D[m + n_serpentine * MmaIterations::kRow]);
                 }
             }
@@ -306,8 +294,8 @@ public:
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-}  // namespace warp
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace warp
+} // namespace gemm
+} // namespace cutlass
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cutlass_extensions/include/cutlass_extensions/gemm/warp/mma_tensorop_dequantizer.h
+++ b/cutlass_extensions/include/cutlass_extensions/gemm/warp/mma_tensorop_dequantizer.h
@@ -52,16 +52,18 @@
 #include "cutlass/functional.h"
 #include "cutlass/platform/platform.h"
 
+////////////////////////////////////////////////////////////////////////////////
+
+namespace cutlass
+{
+namespace gemm
+{
+namespace warp
+{
 
 ////////////////////////////////////////////////////////////////////////////////
 
-namespace cutlass {
-namespace gemm {
-namespace warp {
-
-////////////////////////////////////////////////////////////////////////////////
-
-template<
+template <
     /// Matrix multiply operator
     typename MmaOperator_,
     /// Size of the matrix to load (concept: MatrixShape)
@@ -80,21 +82,15 @@ class MmaTensorOpDequantizer;
 
 ////////////////////////////////////////////////////////////////////////////////
 // Bfloat specialization for Ampere
-template<
+template <
     /// Underlying matrix multiply operator (concept: MmaTensorOp)
     typename MmaOperator_,
     /// Shape of the warp level matrix multiply (concept: GemmShape)
     typename Shape_>
-class MmaTensorOpDequantizer<
-    MmaOperator_,
-    Shape_,
-    Operand::kB,
-    bfloat16_t,
-    layout::RowMajor,
-    32,
-    typename platform::enable_if<
-        MmaOperator_::ArchTag::kMinComputeCapability >= 80
-        && platform::is_same<typename MmaOperator_::ArchMmaOperator::LayoutB, layout::ColumnMajor>::value>::type> {
+class MmaTensorOpDequantizer<MmaOperator_, Shape_, Operand::kB, bfloat16_t, layout::RowMajor, 32,
+    typename platform::enable_if<MmaOperator_::ArchTag::kMinComputeCapability >= 80
+        && platform::is_same<typename MmaOperator_::ArchMmaOperator::LayoutB, layout::ColumnMajor>::value>::type>
+{
 
 public:
     /// Mma Operator
@@ -132,10 +128,10 @@ public:
     CUTLASS_DEVICE
     MmaTensorOpDequantizer(TensorRef smem_scales, const int warp_idx_n, const int lane_idx)
     {
-        const int warp_offset   = warp_idx_n * Shape::kN;
-        const int quad          = lane_idx / 4;
+        const int warp_offset = warp_idx_n * Shape::kN;
+        const int quad = lane_idx / 4;
         const int thread_offset = warp_offset + quad;
-        pointer_                = smem_scales.data() + thread_offset;
+        pointer_ = smem_scales.data() + thread_offset;
     }
 
     CUTLASS_DEVICE
@@ -143,7 +139,8 @@ public:
     {
 
         CUTLASS_PRAGMA_UNROLL
-        for (int mma_n_iter = 0; mma_n_iter < MmaOperator::MmaIterations::kColumn; ++mma_n_iter) {
+        for (int mma_n_iter = 0; mma_n_iter < MmaOperator::MmaIterations::kColumn; ++mma_n_iter)
+        {
             scale_frag[mma_n_iter] = pointer_[mma_n_iter * InstructionShape::kN];
         }
     }
@@ -152,23 +149,25 @@ public:
     void dequantize(FragmentDequantizedOperand& operand_frag, const FragmentScale& scale_frag)
     {
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800) && defined(ENABLE_BF16))
-        using _MmaOperandB        = typename ArchMmaOperator::FragmentB;
+        using _MmaOperandB = typename ArchMmaOperator::FragmentB;
         using ExpandedMmaOperandB = Array<typename _MmaOperandB::Element, kExpansionFactor * _MmaOperandB::kElements>;
         static_assert(ExpandedMmaOperandB::kElements * MmaOperator::MmaIterations::kColumn
-                          == FragmentDequantizedOperand::kElements,
-                      "");
+                == FragmentDequantizedOperand::kElements,
+            "");
 
         const __nv_bfloat16* scale_ptr = reinterpret_cast<const __nv_bfloat16*>(&scale_frag);
 
         ExpandedMmaOperandB* operand_frag_ptr = reinterpret_cast<ExpandedMmaOperandB*>(&operand_frag);
         CUTLASS_PRAGMA_UNROLL
-        for (int mma_n_iter = 0; mma_n_iter < MmaOperator::MmaIterations::kColumn; ++mma_n_iter) {
+        for (int mma_n_iter = 0; mma_n_iter < MmaOperator::MmaIterations::kColumn; ++mma_n_iter)
+        {
             static_assert(ExpandedMmaOperandB::kElements % 2 == 0, "");
 
-            __nv_bfloat162  scalex2            = __bfloat162bfloat162(scale_ptr[mma_n_iter]);
+            __nv_bfloat162 scalex2 = __bfloat162bfloat162(scale_ptr[mma_n_iter]);
             __nv_bfloat162* operand_bf16x2_ptr = reinterpret_cast<__nv_bfloat162*>(&operand_frag_ptr[mma_n_iter]);
             CUTLASS_PRAGMA_UNROLL
-            for (int ii = 0; ii < ExpandedMmaOperandB::kElements / 2; ++ii) {
+            for (int ii = 0; ii < ExpandedMmaOperandB::kElements / 2; ++ii)
+            {
                 operand_bf16x2_ptr[ii] = __hmul2(operand_bf16x2_ptr[ii], scalex2);
             }
         }
@@ -187,21 +186,15 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 // Specialization for Turing & Ampere
-template<
+template <
     /// Underlying matrix multiply operator (concept: MmaTensorOp)
     typename MmaOperator_,
     /// Shape of the warp level matrix multiply (concept: GemmShape)
     typename Shape_>
-class MmaTensorOpDequantizer<
-    MmaOperator_,
-    Shape_,
-    Operand::kB,
-    half_t,
-    layout::RowMajor,
-    32,
-    typename platform::enable_if<
-        MmaOperator_::ArchTag::kMinComputeCapability >= 75
-        && platform::is_same<typename MmaOperator_::ArchMmaOperator::LayoutB, layout::ColumnMajor>::value>::type> {
+class MmaTensorOpDequantizer<MmaOperator_, Shape_, Operand::kB, half_t, layout::RowMajor, 32,
+    typename platform::enable_if<MmaOperator_::ArchTag::kMinComputeCapability >= 75
+        && platform::is_same<typename MmaOperator_::ArchMmaOperator::LayoutB, layout::ColumnMajor>::value>::type>
+{
 
 public:
     /// Mma Operator
@@ -239,10 +232,10 @@ public:
     CUTLASS_DEVICE
     MmaTensorOpDequantizer(TensorRef smem_scales, const int warp_idx_n, const int lane_idx)
     {
-        const int warp_offset   = warp_idx_n * Shape::kN;
-        const int quad          = lane_idx / 4;
+        const int warp_offset = warp_idx_n * Shape::kN;
+        const int quad = lane_idx / 4;
         const int thread_offset = warp_offset + quad;
-        pointer_                = smem_scales.data() + thread_offset;
+        pointer_ = smem_scales.data() + thread_offset;
     }
 
     CUTLASS_DEVICE
@@ -250,7 +243,8 @@ public:
     {
 
         CUTLASS_PRAGMA_UNROLL
-        for (int mma_n_iter = 0; mma_n_iter < MmaOperator::MmaIterations::kColumn; ++mma_n_iter) {
+        for (int mma_n_iter = 0; mma_n_iter < MmaOperator::MmaIterations::kColumn; ++mma_n_iter)
+        {
             scale_frag[mma_n_iter] = pointer_[mma_n_iter * InstructionShape::kN];
         }
     }
@@ -258,17 +252,18 @@ public:
     CUTLASS_DEVICE
     void dequantize(FragmentDequantizedOperand& operand_frag, const FragmentScale& scale_frag)
     {
-        using _MmaOperandB        = typename ArchMmaOperator::FragmentB;
+        using _MmaOperandB = typename ArchMmaOperator::FragmentB;
         using ExpandedMmaOperandB = Array<typename _MmaOperandB::Element, kExpansionFactor * _MmaOperandB::kElements>;
         static_assert(ExpandedMmaOperandB::kElements * MmaOperator::MmaIterations::kColumn
-                          == FragmentDequantizedOperand::kElements,
-                      "");
+                == FragmentDequantizedOperand::kElements,
+            "");
 
         multiplies<ExpandedMmaOperandB> mul_op;
 
         ExpandedMmaOperandB* operand_frag_ptr = reinterpret_cast<ExpandedMmaOperandB*>(&operand_frag);
         CUTLASS_PRAGMA_UNROLL
-        for (int mma_n_iter = 0; mma_n_iter < MmaOperator::MmaIterations::kColumn; ++mma_n_iter) {
+        for (int mma_n_iter = 0; mma_n_iter < MmaOperator::MmaIterations::kColumn; ++mma_n_iter)
+        {
             operand_frag_ptr[mma_n_iter] = mul_op(operand_frag_ptr[mma_n_iter], scale_frag[mma_n_iter]);
         }
     }
@@ -280,21 +275,15 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 // Specialization for Volta A x RowMajor B tensorOp, for 32x32x4 interleaved gemm
-template<
+template <
     /// Underlying matrix multiply operator (concept: MmaTensorOp)
     typename MmaOperator_,
     /// Shape of the warp level matrix multiply (concept: GemmShape)
     typename Shape_>
-class MmaTensorOpDequantizer<
-    MmaOperator_,
-    Shape_,
-    Operand::kB,
-    half_t,
-    layout::RowMajor,
-    32,
-    typename platform::enable_if<
-        platform::is_same<typename MmaOperator_::ArchTag, arch::Sm70>::value
-        && platform::is_same<typename MmaOperator_::ArchMmaOperator::LayoutB, layout::RowMajor>::value>::type> {
+class MmaTensorOpDequantizer<MmaOperator_, Shape_, Operand::kB, half_t, layout::RowMajor, 32,
+    typename platform::enable_if<platform::is_same<typename MmaOperator_::ArchTag, arch::Sm70>::value
+        && platform::is_same<typename MmaOperator_::ArchMmaOperator::LayoutB, layout::RowMajor>::value>::type>
+{
 
 public:
     static_assert(platform::is_same<typename MmaOperator_::InterleavedTileShape, GemmShape<32, 32, 4>>::value, "");
@@ -319,10 +308,10 @@ public:
 
     // Fragment to hold scale data to apply to B before mma
     // Each 32x32x4 matmul uses 8 elements from B.
-    static constexpr int ColsPerMmaTile  = 32;
+    static constexpr int ColsPerMmaTile = 32;
     static constexpr int TileNIterations = Shape::kN / ColsPerMmaTile;
-    using FragmentScale                  = Array<ElementScale, TileNIterations * 8>;
-    using AccessType                     = Array<ElementScale, 8>;
+    using FragmentScale = Array<ElementScale, TileNIterations * 8>;
+    using AccessType = Array<ElementScale, 8>;
 
     /// Layout of the scales in shared memory
     using Layout = layout::RowMajor;
@@ -333,10 +322,10 @@ public:
     CUTLASS_DEVICE
     MmaTensorOpDequantizer(TensorRef smem_scales, const int warp_idx_n, const int lane_idx)
     {
-        const int warp_offset   = warp_idx_n * Shape::kN;
-        const int base_col      = lane_idx & 0xF8;
+        const int warp_offset = warp_idx_n * Shape::kN;
+        const int base_col = lane_idx & 0xF8;
         const int thread_offset = warp_offset + base_col;
-        pointer_                = smem_scales.data() + thread_offset;
+        pointer_ = smem_scales.data() + thread_offset;
     }
 
     CUTLASS_DEVICE
@@ -345,7 +334,8 @@ public:
         AccessType* scale_frag_ptr = reinterpret_cast<AccessType*>(&scale_frag);
 
         CUTLASS_PRAGMA_UNROLL
-        for (int tile_iter = 0; tile_iter < TileNIterations; ++tile_iter) {
+        for (int tile_iter = 0; tile_iter < TileNIterations; ++tile_iter)
+        {
             // We jump by 32 here since volta does <32x32x4> super mmas inside a warp.
             scale_frag_ptr[tile_iter] = *reinterpret_cast<AccessType const*>(pointer_ + ColsPerMmaTile * tile_iter);
         }
@@ -367,21 +357,15 @@ private:
 ////////////////////////////////////////////////////////////////////////////////
 
 // Specialization for Volta A x ColumnMajor B tensorOp, for 32x32x4 interleaved gemm
-template<
+template <
     /// Underlying matrix multiply operator (concept: MmaTensorOp)
     typename MmaOperator_,
     /// Shape of the warp level matrix multiply (concept: GemmShape)
     typename Shape_>
-class MmaTensorOpDequantizer<
-    MmaOperator_,
-    Shape_,
-    Operand::kB,
-    half_t,
-    layout::RowMajor,
-    32,
-    typename platform::enable_if<
-        platform::is_same<typename MmaOperator_::ArchTag, arch::Sm70>::value
-        && platform::is_same<typename MmaOperator_::ArchMmaOperator::LayoutB, layout::ColumnMajor>::value>::type> {
+class MmaTensorOpDequantizer<MmaOperator_, Shape_, Operand::kB, half_t, layout::RowMajor, 32,
+    typename platform::enable_if<platform::is_same<typename MmaOperator_::ArchTag, arch::Sm70>::value
+        && platform::is_same<typename MmaOperator_::ArchMmaOperator::LayoutB, layout::ColumnMajor>::value>::type>
+{
 
 public:
     static_assert(platform::is_same<typename MmaOperator_::InterleavedTileShape, GemmShape<32, 32, 4>>::value, "");
@@ -406,9 +390,9 @@ public:
 
     // Fragment to hold scale data to apply to B before mma
     // Each 32x32x4 matmul uses 8 elements from B.
-    static constexpr int ColsPerMmaTile  = 32;
+    static constexpr int ColsPerMmaTile = 32;
     static constexpr int TileNIterations = Shape::kN / ColsPerMmaTile;
-    using FragmentScale                  = Array<ElementScale, TileNIterations * 2>;
+    using FragmentScale = Array<ElementScale, TileNIterations * 2>;
 
     /// Layout of the scales in shared memory
     using Layout = layout::RowMajor;
@@ -419,22 +403,24 @@ public:
     CUTLASS_DEVICE
     MmaTensorOpDequantizer(TensorRef smem_scales, const int warp_idx_n, const int lane_idx)
     {
-        const int warp_offset   = warp_idx_n * Shape::kN;
-        const int base_col      = lane_idx & 0xF8 + lane_idx % 4;
+        const int warp_offset = warp_idx_n * Shape::kN;
+        const int base_col = lane_idx & 0xF8 + lane_idx % 4;
         const int thread_offset = warp_offset + base_col;
-        pointer_                = smem_scales.data() + thread_offset;
+        pointer_ = smem_scales.data() + thread_offset;
     }
 
     CUTLASS_DEVICE
     void load(FragmentScale& scale_frag)
     {
         CUTLASS_PRAGMA_UNROLL
-        for (int tile_iter = 0; tile_iter < TileNIterations; ++tile_iter) {
+        for (int tile_iter = 0; tile_iter < TileNIterations; ++tile_iter)
+        {
             // We jump by 32 here since volta does <32x32x4> super mmas inside a warp.
             // For col major B, each thread will jump 4 cols to get its next value inside
             // of the super mma.
             CUTLASS_PRAGMA_UNROLL
-            for (int mma_iter = 0; mma_iter < 2; ++mma_iter) {
+            for (int mma_iter = 0; mma_iter < 2; ++mma_iter)
+            {
                 scale_frag[tile_iter * 2 + mma_iter] = pointer_[ColsPerMmaTile * tile_iter + 4 * mma_iter];
             }
         }
@@ -443,7 +429,7 @@ public:
     CUTLASS_DEVICE
     void dequantize(FragmentDequantizedOperand& operand_frag, const FragmentScale& scale_frag)
     {
-        using MmaOperandB                 = typename ArchMmaOperator::FragmentB;
+        using MmaOperandB = typename ArchMmaOperator::FragmentB;
         static constexpr int total_n_mmas = 2 * TileNIterations;
         static_assert(MmaOperandB::kElements * total_n_mmas == FragmentDequantizedOperand::kElements, "");
 
@@ -451,7 +437,8 @@ public:
 
         MmaOperandB* operand_frag_ptr = reinterpret_cast<MmaOperandB*>(&operand_frag);
         CUTLASS_PRAGMA_UNROLL
-        for (int mma_n_iter = 0; mma_n_iter < total_n_mmas; ++mma_n_iter) {
+        for (int mma_n_iter = 0; mma_n_iter < total_n_mmas; ++mma_n_iter)
+        {
             operand_frag_ptr[mma_n_iter] = mul_op(operand_frag_ptr[mma_n_iter], scale_frag[mma_n_iter]);
         }
     }
@@ -462,8 +449,8 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////
 
-}  // namespace warp
-}  // namespace gemm
-}  // namespace cutlass
+} // namespace warp
+} // namespace gemm
+} // namespace cutlass
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
+++ b/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
@@ -40,18 +40,21 @@
 #include "cutlass/half.h"
 #include "cutlass/numeric_types.h"
 
-namespace cutlass {
+namespace cutlass
+{
 
 // This converter is meant to be used with data interleaved in a 32-bit register where the even elements are in the low
 // bits and the odd elemeents are in the high bits of the register. In addition, it assumes elements were originally
 // signed and had a bias of 2**(b-1) added (where b is the number of bits in the type) to make all numbers unsigned.
 // This converter will uninterleave the data and subtract the bias while converting to the result type.
-template<typename T, typename S, int N>
-struct FastInterleavedAndBiasedNumericArrayConverter {
+template <typename T, typename S, int N>
+struct FastInterleavedAndBiasedNumericArrayConverter
+{
 };
 
-template<>
-struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint8_t, 4> {
+template <>
+struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint8_t, 4>
+{
     using result_type = Array<half_t, 4>;
     using source_type = Array<uint8_t, 4>;
 
@@ -60,11 +63,11 @@ struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint8_t, 4> {
     {
         result_type result;
 
-        uint32_t*      h   = reinterpret_cast<uint32_t*>(&result);
+        uint32_t* h = reinterpret_cast<uint32_t*>(&result);
         uint32_t const i8s = reinterpret_cast<uint32_t const&>(source);
 
-        static constexpr uint32_t mask_for_elt_01     = 0x5250;
-        static constexpr uint32_t mask_for_elt_23     = 0x5351;
+        static constexpr uint32_t mask_for_elt_01 = 0x5250;
+        static constexpr uint32_t mask_for_elt_23 = 0x5351;
         static constexpr uint32_t start_byte_for_fp16 = 0x64646464;
         asm volatile("prmt.b32 %0,%1,%2,%3;\n" : "=r"(h[0]) : "r"(i8s), "n"(start_byte_for_fp16), "n"(mask_for_elt_01));
         asm volatile("prmt.b32 %0,%1,%2,%3;\n" : "=r"(h[1]) : "r"(i8s), "n"(start_byte_for_fp16), "n"(mask_for_elt_23));
@@ -84,8 +87,9 @@ struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint8_t, 4> {
     }
 };
 
-template<int N>
-struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint8_t, N> {
+template <int N>
+struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint8_t, N>
+{
     static constexpr int VEC_WIDTH = 4;
     static_assert(!(N % VEC_WIDTH), "N must be multiple of 4.");
 
@@ -104,11 +108,12 @@ struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint8_t, N> {
         using vec_result = Array<scalar_result_type, VEC_WIDTH>;
         using vec_source = Array<scalar_source_type, VEC_WIDTH>;
 
-        vec_result*       result_ptr = reinterpret_cast<vec_result*>(&result);
+        vec_result* result_ptr = reinterpret_cast<vec_result*>(&result);
         vec_source const* source_ptr = reinterpret_cast<vec_source const*>(&source);
 
         CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < N / VEC_WIDTH; ++i) {
+        for (int i = 0; i < N / VEC_WIDTH; ++i)
+        {
             result_ptr[i] = convert_vector_(source_ptr[i]);
         }
 
@@ -122,8 +127,9 @@ struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint8_t, N> {
     }
 };
 
-template<>
-struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint8_t, 4> {
+template <>
+struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint8_t, 4>
+{
     using result_type = Array<bfloat16_t, 4>;
     using source_type = Array<uint8_t, 4>;
 
@@ -133,35 +139,37 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint8_t, 4> {
         result_type result;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
 
-        uint32_t*      bf16_result_ptr = reinterpret_cast<uint32_t*>(&result);
-        uint32_t const i8s             = reinterpret_cast<uint32_t const&>(source);
+        uint32_t* bf16_result_ptr = reinterpret_cast<uint32_t*>(&result);
+        uint32_t const i8s = reinterpret_cast<uint32_t const&>(source);
 
         static constexpr uint32_t fp32_base = 0x4B000000;
-        float                     fp32_intermediates[4];
+        float fp32_intermediates[4];
 
         // Construct FP32s, bfloat does not have enough mantissa for IADD trick
         uint32_t* fp32_intermediates_casted = reinterpret_cast<uint32_t*>(fp32_intermediates);
-        fp32_intermediates_casted[0]        = __byte_perm(i8s, fp32_base, 0x7650);
-        fp32_intermediates_casted[1]        = __byte_perm(i8s, fp32_base, 0x7652);
-        fp32_intermediates_casted[2]        = __byte_perm(i8s, fp32_base, 0x7651);
-        fp32_intermediates_casted[3]        = __byte_perm(i8s, fp32_base, 0x7653);
+        fp32_intermediates_casted[0] = __byte_perm(i8s, fp32_base, 0x7650);
+        fp32_intermediates_casted[1] = __byte_perm(i8s, fp32_base, 0x7652);
+        fp32_intermediates_casted[2] = __byte_perm(i8s, fp32_base, 0x7651);
+        fp32_intermediates_casted[3] = __byte_perm(i8s, fp32_base, 0x7653);
 
         // Subtract out fp32_base + 128 to make the unsigned integer signed.
         CUTLASS_PRAGMA_UNROLL
-        for (int ii = 0; ii < 4; ++ii) {
+        for (int ii = 0; ii < 4; ++ii)
+        {
             fp32_intermediates[ii] -= 8388736.f;
         }
 
         // Truncate the fp32 representation and pack up as bfloat16s.
         CUTLASS_PRAGMA_UNROLL
-        for (int ii = 0; ii < 2; ++ii) {
-            bf16_result_ptr[ii] =
-                __byte_perm(fp32_intermediates_casted[2 * ii + 0], fp32_intermediates_casted[2 * ii + 1], 0x7632);
+        for (int ii = 0; ii < 2; ++ii)
+        {
+            bf16_result_ptr[ii]
+                = __byte_perm(fp32_intermediates_casted[2 * ii + 0], fp32_intermediates_casted[2 * ii + 1], 0x7632);
         }
 #else
         // Disable this on architectures older than Ampere since they lack hardware for bf16 mma. If one wishes to use
         // HMMA on older hardware, they should Convert directly to FP16 using FP16 converters.
-        result.clear();  // Suppress compiler warning
+        result.clear(); // Suppress compiler warning
         arch::device_breakpoint();
 #endif
         return result;
@@ -174,8 +182,9 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint8_t, 4> {
     }
 };
 
-template<int N>
-struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint8_t, N> {
+template <int N>
+struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint8_t, N>
+{
     static constexpr int VEC_WIDTH = 4;
     static_assert(!(N % VEC_WIDTH), "N must be multiple of 4.");
 
@@ -194,11 +203,12 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint8_t, N> {
         using vec_result = Array<scalar_result_type, VEC_WIDTH>;
         using vec_source = Array<scalar_source_type, VEC_WIDTH>;
 
-        vec_result*       result_ptr = reinterpret_cast<vec_result*>(&result);
+        vec_result* result_ptr = reinterpret_cast<vec_result*>(&result);
         vec_source const* source_ptr = reinterpret_cast<vec_source const*>(&source);
 
         CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < N / VEC_WIDTH; ++i) {
+        for (int i = 0; i < N / VEC_WIDTH; ++i)
+        {
             result_ptr[i] = convert_vector_(source_ptr[i]);
         }
 
@@ -212,8 +222,9 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint8_t, N> {
     }
 };
 
-template<>
-struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint4b_t, 8> {
+template <>
+struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint4b_t, 8>
+{
     using result_type = Array<half_t, 8>;
     using source_type = Array<uint4b_t, 8>;
 
@@ -222,13 +233,13 @@ struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint4b_t, 8> {
     {
         result_type result;
 
-        uint32_t*      h   = reinterpret_cast<uint32_t*>(&result);
+        uint32_t* h = reinterpret_cast<uint32_t*>(&result);
         uint32_t const i4s = reinterpret_cast<uint32_t const&>(source);
 
         // First, we extract the i4s and construct an intermediate fp16 number.
-        static constexpr uint32_t immLut                = (0xf0 & 0xcc) | 0xaa;
-        static constexpr uint32_t BOTTOM_MASK           = 0x000f000f;
-        static constexpr uint32_t TOP_MASK              = 0x00f000f0;
+        static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+        static constexpr uint32_t BOTTOM_MASK = 0x000f000f;
+        static constexpr uint32_t TOP_MASK = 0x00f000f0;
         static constexpr uint32_t I4s_TO_F16s_MAGIC_NUM = 0x64006400;
 
         // Note that the entire sequence only requires 1 shift instruction. This is thanks to the register packing
@@ -286,8 +297,9 @@ struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint4b_t, 8> {
     }
 };
 
-template<int N>
-struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint4b_t, N> {
+template <int N>
+struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint4b_t, N>
+{
     static constexpr int VEC_WIDTH = 8;
     static_assert(!(N % VEC_WIDTH), "N must be multiple of 8.");
 
@@ -306,11 +318,12 @@ struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint4b_t, N> {
         using vec_result = Array<scalar_result_type, VEC_WIDTH>;
         using vec_source = Array<scalar_source_type, VEC_WIDTH>;
 
-        vec_result*       result_ptr = reinterpret_cast<vec_result*>(&result);
+        vec_result* result_ptr = reinterpret_cast<vec_result*>(&result);
         vec_source const* source_ptr = reinterpret_cast<vec_source const*>(&source);
 
         CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < N / VEC_WIDTH; ++i) {
+        for (int i = 0; i < N / VEC_WIDTH; ++i)
+        {
             result_ptr[i] = convert_vector_(source_ptr[i]);
         }
 
@@ -324,8 +337,9 @@ struct FastInterleavedAndBiasedNumericArrayConverter<half_t, uint4b_t, N> {
     }
 };
 
-template<>
-struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, 8> {
+template <>
+struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, 8>
+{
     using result_type = Array<bfloat16_t, 8>;
     using source_type = Array<uint4b_t, 8>;
 
@@ -335,12 +349,12 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, 8> {
         result_type result;
 #if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
 
-        uint32_t*      h          = reinterpret_cast<uint32_t*>(&result);
+        uint32_t* h = reinterpret_cast<uint32_t*>(&result);
         uint32_t const source_i4s = reinterpret_cast<uint32_t const&>(source);
 
         // First, we extract the i4s and construct an intermediate fp16 number.
-        static constexpr uint32_t immLut                 = (0xf0 & 0xcc) | 0xaa;
-        static constexpr uint32_t MASK                   = 0x000f000f;
+        static constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+        static constexpr uint32_t MASK = 0x000f000f;
         static constexpr uint32_t I4s_TO_BF16s_MAGIC_NUM = 0x43004300;
 
         // We don't have enough mantissa to remove as much shift overhead as FP16, so we must loop.
@@ -350,7 +364,8 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, 8> {
                      : "=r"(h[0])
                      : "r"(i4s), "n"(MASK), "n"(I4s_TO_BF16s_MAGIC_NUM), "n"(immLut));
         CUTLASS_PRAGMA_UNROLL
-        for (int ii = 1; ii < result_type::kElements / 2; ++ii) {
+        for (int ii = 1; ii < result_type::kElements / 2; ++ii)
+        {
             i4s >>= sizeof_bits<typename source_type::Element>::value;
             // (i4s & 0x000f000f) | 0x43004300
             asm volatile("lop3.b32 %0, %1, %2, %3, %4;\n"
@@ -360,11 +375,12 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, 8> {
 
         // This is the BF16 {-136, -136} represented as an integer.
         static constexpr uint32_t BF16_BIAS = 0xC308C308;
-        static constexpr uint32_t BF16_ONE  = 0x3F803F80;
+        static constexpr uint32_t BF16_ONE = 0x3F803F80;
 
         // Finally, we construct the output numbers.
         CUTLASS_PRAGMA_UNROLL
-        for (int ii = 0; ii < result_type::kElements / 2; ++ii) {
+        for (int ii = 0; ii < result_type::kElements / 2; ++ii)
+        {
             // Since this section is for Ampere+, we use bf16 fma to do the bias subtraction
             asm("fma.rn.bf16x2 %0, %1, %2, %3;\n" : "=r"(h[ii]) : "r"(h[ii]), "r"(BF16_ONE), "r"(BF16_BIAS));
         }
@@ -372,7 +388,7 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, 8> {
         // Disable this on architectures older than Ampere since they lack hardware for bf16 mma. If one wishes to use
         // HMMA on older hardware, they should Convert directly to FP16 using FP16 converters.
         arch::device_breakpoint();
-        result.clear();  // Suppress compiler warning.
+        result.clear(); // Suppress compiler warning.
 #endif
         return result;
     }
@@ -384,8 +400,9 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, 8> {
     }
 };
 
-template<int N>
-struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, N> {
+template <int N>
+struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, N>
+{
     static constexpr int VEC_WIDTH = 8;
     static_assert(!(N % VEC_WIDTH), "N must be multiple of 8.");
 
@@ -404,11 +421,12 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, N> {
         using vec_result = Array<scalar_result_type, VEC_WIDTH>;
         using vec_source = Array<scalar_source_type, VEC_WIDTH>;
 
-        vec_result*       result_ptr = reinterpret_cast<vec_result*>(&result);
+        vec_result* result_ptr = reinterpret_cast<vec_result*>(&result);
         vec_source const* source_ptr = reinterpret_cast<vec_source const*>(&source);
 
         CUTLASS_PRAGMA_UNROLL
-        for (int i = 0; i < N / VEC_WIDTH; ++i) {
+        for (int i = 0; i < N / VEC_WIDTH; ++i)
+        {
             result_ptr[i] = convert_vector_(source_ptr[i]);
         }
 
@@ -424,6 +442,6 @@ struct FastInterleavedAndBiasedNumericArrayConverter<bfloat16_t, uint4b_t, N> {
 
 /////////////////////////////////////////////////////////////////////////////////////////////////
 
-}  // namespace cutlass
+} // namespace cutlass
 
 /////////////////////////////////////////////////////////////////////////////////////////////////

--- a/cutlass_extensions/include/cutlass_extensions/tile_interleaved_layout.h
+++ b/cutlass_extensions/include/cutlass_extensions/tile_interleaved_layout.h
@@ -38,24 +38,29 @@
 #include "cutlass/matrix_coord.h"
 #include "cutlass/pitch_linear_coord.h"
 
-namespace cutlass {
-namespace layout {
+namespace cutlass
+{
+namespace layout
+{
 
-template<int RowsPerTile, int ColumnsInterleaved>
-class ColumnMajorTileInterleave {
-    static constexpr int kRowsPerTile        = RowsPerTile;
+template <int RowsPerTile, int ColumnsInterleaved>
+class ColumnMajorTileInterleave
+{
+    static constexpr int kRowsPerTile = RowsPerTile;
     static constexpr int kColumnsInterleaved = ColumnsInterleaved;
 };
 
-template<class T>
-struct IsColumnMajorTileInterleave {
+template <class T>
+struct IsColumnMajorTileInterleave
+{
     static constexpr bool value = false;
 };
 
-template<int U, int V>
-struct IsColumnMajorTileInterleave<ColumnMajorTileInterleave<U, V>> {
+template <int U, int V>
+struct IsColumnMajorTileInterleave<ColumnMajorTileInterleave<U, V>>
+{
     static constexpr bool value = true;
 };
 
-}  // namespace layout
-}  // namespace cutlass
+} // namespace layout
+} // namespace cutlass

--- a/cutlass_kernels/cutlass_heuristic.cc
+++ b/cutlass_kernels/cutlass_heuristic.cc
@@ -18,67 +18,66 @@
 #include "cutlass/gemm/gemm.h"
 #include <cuda_runtime_api.h>
 
-#include <vector>
 #include <stdexcept>
+#include <vector>
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
-struct TileShape {
+struct TileShape
+{
     int m;
     int n;
 };
 
 TileShape get_cta_shape_for_config(CutlassTileConfig tile_config)
 {
-    switch (tile_config) {
-        case CutlassTileConfig::CtaShape32x128x64_WarpShape32x32x64:
-            return TileShape{32, 128};
-        case CutlassTileConfig::CtaShape64x128x64_WarpShape32x64x64:
-        case CutlassTileConfig::CtaShape64x128x64_WarpShape64x32x64:
-            return TileShape{64, 128};
-        case CutlassTileConfig::CtaShape128x128x8_WarpShape64x64x8:
-        case CutlassTileConfig::CtaShape128x128x64_WarpShape64x32x64:
-        case CutlassTileConfig::CtaShape128x128x64_WarpShape128x32x64:
-            return TileShape{128, 128};
-        default:
-            throw std::runtime_error("[FT Error][get_grid_shape_for_config] Invalid config");
+    switch (tile_config)
+    {
+    case CutlassTileConfig::CtaShape32x128x64_WarpShape32x32x64: return TileShape{32, 128};
+    case CutlassTileConfig::CtaShape64x128x64_WarpShape32x64x64:
+    case CutlassTileConfig::CtaShape64x128x64_WarpShape64x32x64: return TileShape{64, 128};
+    case CutlassTileConfig::CtaShape128x128x8_WarpShape64x64x8:
+    case CutlassTileConfig::CtaShape128x128x64_WarpShape64x32x64:
+    case CutlassTileConfig::CtaShape128x128x64_WarpShape128x32x64: return TileShape{128, 128};
+    default: throw std::runtime_error("[FT Error][get_grid_shape_for_config] Invalid config");
     }
 }
 
-bool is_valid_split_k_factor(const int64_t   m,
-                             const int64_t   n,
-                             const int64_t   k,
-                             const TileShape tile_shape,
-                             const int       split_k_factor,
-                             const size_t    workspace_bytes,
-                             const bool      is_weight_only)
+bool is_valid_split_k_factor(const int64_t m, const int64_t n, const int64_t k, const TileShape tile_shape,
+    const int split_k_factor, const size_t workspace_bytes, const bool is_weight_only)
 {
 
     // All tile sizes have a k_tile of 64.
     static constexpr int k_tile = 64;
 
     // For weight-only quant, we need k and k_elements_per_split to be a multiple of cta_k
-    if (is_weight_only) {
-        if ((k % k_tile) != 0) {
+    if (is_weight_only)
+    {
+        if ((k % k_tile) != 0)
+        {
             return false;
         }
 
-        if ((k % split_k_factor) != 0) {
+        if ((k % split_k_factor) != 0)
+        {
             return false;
         }
 
         const int k_elements_per_split = k / split_k_factor;
-        if ((k_elements_per_split % k_tile) != 0) {
+        if ((k_elements_per_split % k_tile) != 0)
+        {
             return false;
         }
     }
 
     // Check that the workspace has sufficient space for this split-k factor
-    const int ctas_in_m_dim     = (m + tile_shape.m - 1) / tile_shape.m;
-    const int ctas_in_n_dim     = (n + tile_shape.n - 1) / tile_shape.n;
+    const int ctas_in_m_dim = (m + tile_shape.m - 1) / tile_shape.m;
+    const int ctas_in_n_dim = (n + tile_shape.n - 1) / tile_shape.n;
     const size_t required_ws_bytes = split_k_factor == 1 ? 0 : sizeof(int) * ctas_in_m_dim * ctas_in_n_dim;
 
-    if (required_ws_bytes > workspace_bytes) {
+    if (required_ws_bytes > workspace_bytes)
+    {
         return false;
     }
 
@@ -91,12 +90,12 @@ std::vector<CutlassTileConfig> get_candidate_tiles(const bool is_weight_only, co
     std::vector<CutlassTileConfig> simt_configs{CutlassTileConfig::CtaShape128x128x8_WarpShape64x64x8};
 
     std::vector<CutlassTileConfig> square_configs{CutlassTileConfig::CtaShape32x128x64_WarpShape32x32x64,
-                                                  CutlassTileConfig::CtaShape64x128x64_WarpShape32x64x64,
-                                                  CutlassTileConfig::CtaShape128x128x64_WarpShape64x32x64};
+        CutlassTileConfig::CtaShape64x128x64_WarpShape32x64x64,
+        CutlassTileConfig::CtaShape128x128x64_WarpShape64x32x64};
 
     std::vector<CutlassTileConfig> quant_B_configs{CutlassTileConfig::CtaShape32x128x64_WarpShape32x32x64,
-                                                   CutlassTileConfig::CtaShape64x128x64_WarpShape64x32x64,
-                                                   CutlassTileConfig::CtaShape128x128x64_WarpShape128x32x64};
+        CutlassTileConfig::CtaShape64x128x64_WarpShape64x32x64,
+        CutlassTileConfig::CtaShape128x128x64_WarpShape128x32x64};
 
     const std::vector<CutlassTileConfig> allowed_configs = is_weight_only ? quant_B_configs : square_configs;
     return simt_configs_only ? simt_configs : allowed_configs;
@@ -107,11 +106,13 @@ std::vector<CutlassGemmConfig> get_candidate_configs(int sm, const bool is_weigh
     std::vector<CutlassTileConfig> tiles = get_candidate_tiles(is_weight_only, simt_configs_only);
 
     std::vector<CutlassGemmConfig> candidate_configs;
-    const int                      min_stages = 2;
-    const int                      max_stages = sm >= 80 ? 4 : 2;
+    const int min_stages = 2;
+    const int max_stages = sm >= 80 ? 4 : 2;
 
-    for (const auto& tile_config : tiles) {
-        for (int stages = min_stages; stages <= max_stages; ++stages) {
+    for (const auto& tile_config : tiles)
+    {
+        for (int stages = min_stages; stages <= max_stages; ++stages)
+        {
             CutlassGemmConfig config{tile_config, SplitKStyle::NO_SPLIT_K, 1, stages};
             candidate_configs.push_back(config);
         }
@@ -121,88 +122,91 @@ std::vector<CutlassGemmConfig> get_candidate_configs(int sm, const bool is_weigh
 }
 
 CutlassGemmConfig estimate_best_config_from_occupancies(const std::vector<CutlassGemmConfig>& candidate_configs,
-                                                        const std::vector<int>&               occupancies,
-                                                        const int64_t                         m,
-                                                        const int64_t                         n,
-                                                        const int64_t                         k,
-                                                        const int64_t                         num_experts,
-                                                        const int                             split_k_limit,
-                                                        const size_t                          workspace_bytes,
-                                                        const int                             multi_processor_count,
-                                                        const int                             is_weight_only)
+    const std::vector<int>& occupancies, const int64_t m, const int64_t n, const int64_t k, const int64_t num_experts,
+    const int split_k_limit, const size_t workspace_bytes, const int multi_processor_count, const int is_weight_only)
 {
 
-    if (occupancies.size() != candidate_configs.size()) {
-        throw std::runtime_error("[FT Error][estimate_best_config_from_occupancies] occpancies and "
-                                 "candidate configs vectors must have equal length.");
+    if (occupancies.size() != candidate_configs.size())
+    {
+        throw std::runtime_error(
+            "[FT Error][estimate_best_config_from_occupancies] occpancies and "
+            "candidate configs vectors must have equal length.");
     }
 
     CutlassGemmConfig best_config;
     // Score will be [0, 1]. The objective is to minimize this score.
     // It represents the fraction of SM resources unused in the last wave.
-    float config_score   = 1.0f;
-    int   config_waves   = INT_MAX;
-    int   current_m_tile = 0;
+    float config_score = 1.0f;
+    int config_waves = INT_MAX;
+    int current_m_tile = 0;
 
     const int max_split_k = n >= multi_processor_count * 256 ? 1 : split_k_limit;
-    for (size_t ii = 0; ii < candidate_configs.size(); ++ii) {
+    for (size_t ii = 0; ii < candidate_configs.size(); ++ii)
+    {
         CutlassGemmConfig candidate_config = candidate_configs[ii];
-        TileShape         tile_shape       = get_cta_shape_for_config(candidate_config.tile_config);
-        int               occupancy        = occupancies[ii];
+        TileShape tile_shape = get_cta_shape_for_config(candidate_config.tile_config);
+        int occupancy = occupancies[ii];
 
-        if (occupancy == 0) {
+        if (occupancy == 0)
+        {
             continue;
         }
 
         // Keep small tile sizes when possible.
         if (best_config.tile_config != CutlassTileConfig::ChooseWithHeuristic && m < current_m_tile
-            && current_m_tile < tile_shape.m) {
+            && current_m_tile < tile_shape.m)
+        {
             continue;
         }
 
         const int ctas_in_m_dim = (m + tile_shape.m - 1) / tile_shape.m;
         const int ctas_in_n_dim = (n + tile_shape.n - 1) / tile_shape.n;
 
-        for (int split_k_factor = 1; split_k_factor <= max_split_k; ++split_k_factor) {
-            if (is_valid_split_k_factor(m, n, k, tile_shape, split_k_factor, workspace_bytes, is_weight_only)) {
-                const int ctas_per_wave    = occupancy * multi_processor_count;
+        for (int split_k_factor = 1; split_k_factor <= max_split_k; ++split_k_factor)
+        {
+            if (is_valid_split_k_factor(m, n, k, tile_shape, split_k_factor, workspace_bytes, is_weight_only))
+            {
+                const int ctas_per_wave = occupancy * multi_processor_count;
                 const int ctas_for_problem = ctas_in_m_dim * ctas_in_n_dim * split_k_factor;
 
-                const int   num_waves_total      = (ctas_for_problem + ctas_per_wave - 1) / ctas_per_wave;
+                const int num_waves_total = (ctas_for_problem + ctas_per_wave - 1) / ctas_per_wave;
                 const float num_waves_fractional = ctas_for_problem / float(ctas_per_wave);
-                const float current_score        = float(num_waves_total) - num_waves_fractional;
+                const float current_score = float(num_waves_total) - num_waves_fractional;
 
                 const float score_slack = 0.1f;
                 if (current_score < config_score
-                    || ((config_waves > num_waves_total) && (current_score < config_score + score_slack))) {
+                    || ((config_waves > num_waves_total) && (current_score < config_score + score_slack)))
+                {
                     config_score = current_score;
                     config_waves = num_waves_total;
-                    SplitKStyle split_style =
-                        split_k_factor > 1 ? SplitKStyle::SPLIT_K_SERIAL : SplitKStyle::NO_SPLIT_K;
+                    SplitKStyle split_style
+                        = split_k_factor > 1 ? SplitKStyle::SPLIT_K_SERIAL : SplitKStyle::NO_SPLIT_K;
                     best_config = CutlassGemmConfig{
                         candidate_config.tile_config, split_style, split_k_factor, candidate_config.stages};
                     current_m_tile = tile_shape.m;
                 }
                 else if (current_score == config_score
-                         && (best_config.stages < candidate_config.stages || split_k_factor < best_config.split_k_factor
-                             || current_m_tile < tile_shape.m)) {
+                    && (best_config.stages < candidate_config.stages || split_k_factor < best_config.split_k_factor
+                        || current_m_tile < tile_shape.m))
+                {
                     // Prefer deeper pipeline or smaller split-k
-                    SplitKStyle split_style =
-                        split_k_factor > 1 ? SplitKStyle::SPLIT_K_SERIAL : SplitKStyle::NO_SPLIT_K;
+                    SplitKStyle split_style
+                        = split_k_factor > 1 ? SplitKStyle::SPLIT_K_SERIAL : SplitKStyle::NO_SPLIT_K;
                     best_config = CutlassGemmConfig{
                         candidate_config.tile_config, split_style, split_k_factor, candidate_config.stages};
                     current_m_tile = tile_shape.m;
-                    config_waves   = num_waves_total;
+                    config_waves = num_waves_total;
                 }
             }
         }
     }
 
-    if (best_config.tile_config == CutlassTileConfig::ChooseWithHeuristic) {
+    if (best_config.tile_config == CutlassTileConfig::ChooseWithHeuristic)
+    {
         throw std::runtime_error("[FT Error] Heurisitc failed to find a valid config.");
     }
 
     return best_config;
 }
 
-}  // namespace fastertransformer
+} // namespace fastertransformer

--- a/cutlass_kernels/cutlass_heuristic.h
+++ b/cutlass_kernels/cutlass_heuristic.h
@@ -16,24 +16,18 @@
 
 #pragma once
 
-#include <vector>
+#include "cutlass_extensions/ft_gemm_configs.h"
 #include <cstddef>
 #include <cstdint>
-#include "cutlass_extensions/ft_gemm_configs.h"
+#include <vector>
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
 std::vector<CutlassGemmConfig> get_candidate_configs(int sm, const bool is_weight_only, const bool simt_configs_only);
 
 CutlassGemmConfig estimate_best_config_from_occupancies(const std::vector<CutlassGemmConfig>& candidate_configs,
-                                                        const std::vector<int>&               occupancies,
-                                                        const int64_t                         m,
-                                                        const int64_t                         n,
-                                                        const int64_t                         k,
-                                                        const int64_t                         num_experts,
-                                                        const int                             split_k_limit,
-                                                        const size_t                          workspace_bytes,
-                                                        const int                             multi_processor_count,
-                                                        const int                             is_weight_only);
+    const std::vector<int>& occupancies, const int64_t m, const int64_t n, const int64_t k, const int64_t num_experts,
+    const int split_k_limit, const size_t workspace_bytes, const int multi_processor_count, const int is_weight_only);
 
-}  // namespace fastertransformer
+} // namespace fastertransformer

--- a/cutlass_kernels/cutlass_preprocessors.cc
+++ b/cutlass_kernels/cutlass_preprocessors.cc
@@ -19,41 +19,49 @@
 
 #include <vector>
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
-enum class QuantType { INT8_WEIGHT_ONLY, PACKED_INT4_WEIGHT_ONLY };
+enum class QuantType
+{
+    INT8_WEIGHT_ONLY,
+    PACKED_INT4_WEIGHT_ONLY
+};
 
-int get_bits_in_quant_type(QuantType quant_type) {
-  switch (quant_type) {
-  case QuantType::INT8_WEIGHT_ONLY:
-    return 8;
-  case QuantType::PACKED_INT4_WEIGHT_ONLY:
-    return 4;
-  default:
-    return -1;
-  }
+int get_bits_in_quant_type(QuantType quant_type)
+{
+    switch (quant_type)
+    {
+    case QuantType::INT8_WEIGHT_ONLY: return 8;
+    case QuantType::PACKED_INT4_WEIGHT_ONLY: return 4;
+    default: return -1;
+    }
 }
 
-struct LayoutDetails {
-    enum class Layout {
+struct LayoutDetails
+{
+    enum class Layout
+    {
         UNKNOWN,
         ROW_MAJOR,
         COLUMN_MAJOR
     };
 
-    Layout layoutB              = Layout::UNKNOWN;
-    int    rows_per_column_tile = 1;
-    int    columns_interleaved  = 1;
+    Layout layoutB = Layout::UNKNOWN;
+    int rows_per_column_tile = 1;
+    int columns_interleaved = 1;
 
     bool uses_imma_ldsm = false;
 };
 
-template<typename Layout>
-struct getLayoutDetails {
+template <typename Layout>
+struct getLayoutDetails
+{
 };
 
-template<>
-struct getLayoutDetails<cutlass::layout::RowMajor> {
+template <>
+struct getLayoutDetails<cutlass::layout::RowMajor>
+{
     LayoutDetails operator()()
     {
         LayoutDetails layout_details;
@@ -62,8 +70,9 @@ struct getLayoutDetails<cutlass::layout::RowMajor> {
     }
 };
 
-template<>
-struct getLayoutDetails<cutlass::layout::ColumnMajor> {
+template <>
+struct getLayoutDetails<cutlass::layout::ColumnMajor>
+{
     LayoutDetails operator()()
     {
         LayoutDetails layout_details;
@@ -72,41 +81,45 @@ struct getLayoutDetails<cutlass::layout::ColumnMajor> {
     }
 };
 
-template<int RowsPerTile, int ColumnsInterleaved>
-struct getLayoutDetails<cutlass::layout::ColumnMajorTileInterleave<RowsPerTile, ColumnsInterleaved>> {
+template <int RowsPerTile, int ColumnsInterleaved>
+struct getLayoutDetails<cutlass::layout::ColumnMajorTileInterleave<RowsPerTile, ColumnsInterleaved>>
+{
     LayoutDetails operator()()
     {
         LayoutDetails layout_details;
-        layout_details.layoutB              = LayoutDetails::Layout::COLUMN_MAJOR;
+        layout_details.layoutB = LayoutDetails::Layout::COLUMN_MAJOR;
         layout_details.rows_per_column_tile = RowsPerTile;
-        layout_details.columns_interleaved  = ColumnsInterleaved;
+        layout_details.columns_interleaved = ColumnsInterleaved;
         return layout_details;
     }
 };
 
-template<typename cutlassArch, typename TypeB>
+template <typename cutlassArch, typename TypeB>
 LayoutDetails getLayoutDetailsForArchAndQuantType()
 {
 
-    using CompileTraits    = cutlass::gemm::kernel::LayoutDetailsB<TypeB, cutlassArch>;
-    using LayoutB          = typename CompileTraits::Layout;
-    using MmaOperator      = typename CompileTraits::Operator;
-    LayoutDetails details  = getLayoutDetails<LayoutB>()();
+    using CompileTraits = cutlass::gemm::kernel::LayoutDetailsB<TypeB, cutlassArch>;
+    using LayoutB = typename CompileTraits::Layout;
+    using MmaOperator = typename CompileTraits::Operator;
+    LayoutDetails details = getLayoutDetails<LayoutB>()();
     details.uses_imma_ldsm = std::is_same<MmaOperator, cutlass::arch::OpMultiplyAddDequantizeInterleavedBToA>::value;
     return details;
 }
 
-template<typename cutlassArch>
+template <typename cutlassArch>
 LayoutDetails getLayoutDetailsForArch(QuantType quant_type)
 {
     LayoutDetails details;
-    if (quant_type == QuantType::INT8_WEIGHT_ONLY) {
+    if (quant_type == QuantType::INT8_WEIGHT_ONLY)
+    {
         details = getLayoutDetailsForArchAndQuantType<cutlassArch, uint8_t>();
     }
-    else if (quant_type == QuantType::PACKED_INT4_WEIGHT_ONLY) {
+    else if (quant_type == QuantType::PACKED_INT4_WEIGHT_ONLY)
+    {
         details = getLayoutDetailsForArchAndQuantType<cutlassArch, cutlass::uint4b_t>();
     }
-    else {
+    else
+    {
         FT_CHECK_WITH_INFO(false, "Unsupported quantization type");
     }
     return details;
@@ -114,16 +127,20 @@ LayoutDetails getLayoutDetailsForArch(QuantType quant_type)
 
 LayoutDetails getLayoutDetailsForTransform(QuantType quant_type, int arch)
 {
-    if (arch >= 70 && arch < 75) {
+    if (arch >= 70 && arch < 75)
+    {
         return getLayoutDetailsForArch<cutlass::arch::Sm70>(quant_type);
     }
-    else if (arch >= 75 && arch < 80) {
+    else if (arch >= 75 && arch < 80)
+    {
         return getLayoutDetailsForArch<cutlass::arch::Sm75>(quant_type);
     }
-    else if (arch >= 80 && arch < 90) {
+    else if (arch >= 80 && arch < 90)
+    {
         return getLayoutDetailsForArch<cutlass::arch::Sm80>(quant_type);
     }
-    else {
+    else
+    {
         FT_CHECK_WITH_INFO(false, "Unsupported Arch");
         return LayoutDetails();
     }
@@ -136,64 +153,61 @@ LayoutDetails getLayoutDetailsForTransform(QuantType quant_type, int arch)
 // For int4, each group of 32 rows is permuted using the map below:
 //  0 1 8 9 16 17 24 25 2 3 10 11 18 19 26 27 4 5 12 13 20 21 28 29 6 7 14 15 22
 //  23 30 31
-void permute_B_rows_for_mixed_gemm(int8_t *permuted_quantized_tensor,
-                                   const int8_t *quantized_tensor,
-                                   const std::vector<size_t> &shape,
-                                   QuantType quant_type,
-                                   const int64_t arch_version) {
-  const size_t num_rows = shape[0];
-  const size_t num_cols = shape[1];
+void permute_B_rows_for_mixed_gemm(int8_t* permuted_quantized_tensor, const int8_t* quantized_tensor,
+    const std::vector<size_t>& shape, QuantType quant_type, const int64_t arch_version)
+{
+    const size_t num_rows = shape[0];
+    const size_t num_cols = shape[1];
 
-  const int BITS_PER_ELT = get_bits_in_quant_type(quant_type);
-  const int K = 16 / BITS_PER_ELT;
-  const int ELTS_PER_REG = 32 / BITS_PER_ELT;
+    const int BITS_PER_ELT = get_bits_in_quant_type(quant_type);
+    const int K = 16 / BITS_PER_ELT;
+    const int ELTS_PER_REG = 32 / BITS_PER_ELT;
 
-  const uint32_t *input_byte_ptr =
-      reinterpret_cast<const uint32_t *>(quantized_tensor);
-  uint32_t *output_byte_ptr =
-      reinterpret_cast<uint32_t *>(permuted_quantized_tensor);
+    const uint32_t* input_byte_ptr = reinterpret_cast<const uint32_t*>(quantized_tensor);
+    uint32_t* output_byte_ptr = reinterpret_cast<uint32_t*>(permuted_quantized_tensor);
 
-  int MMA_SHAPE_N = 8;
-  int B_ROWS_PER_MMA = 8 * K;
-  const int elts_in_int32 = 32 / BITS_PER_ELT;
+    int MMA_SHAPE_N = 8;
+    int B_ROWS_PER_MMA = 8 * K;
+    const int elts_in_int32 = 32 / BITS_PER_ELT;
 
-  const int num_vec_cols = num_cols / elts_in_int32;
+    const int num_vec_cols = num_cols / elts_in_int32;
 
-  FT_CHECK_WITH_INFO(arch_version >= 75,
-                     "Unsupported Arch. Pre-volta not supported. Column "
-                     "interleave not needed on Volta.");
+    FT_CHECK_WITH_INFO(arch_version >= 75,
+        "Unsupported Arch. Pre-volta not supported. Column "
+        "interleave not needed on Volta.");
 
-  FT_CHECK_WITH_INFO(num_rows % B_ROWS_PER_MMA == 0,
-                     fmtstr("Invalid shape for quantized tensor. Number of "
-                            "rows of quantized matrix must be a multiple of %d",
-                            B_ROWS_PER_MMA));
+    FT_CHECK_WITH_INFO(num_rows % B_ROWS_PER_MMA == 0,
+        fmtstr("Invalid shape for quantized tensor. Number of "
+               "rows of quantized matrix must be a multiple of %d",
+            B_ROWS_PER_MMA));
 
-  FT_CHECK_WITH_INFO(
-      num_cols % MMA_SHAPE_N == 0,
-      fmtstr("Invalid shape for quantized tensor. On turing/Ampere, the number "
-             "of cols must be a multiple of %d.",
-             MMA_SHAPE_N));
+    FT_CHECK_WITH_INFO(num_cols % MMA_SHAPE_N == 0,
+        fmtstr("Invalid shape for quantized tensor. On turing/Ampere, the number "
+               "of cols must be a multiple of %d.",
+            MMA_SHAPE_N));
 
-  // The code is written as below so it works for both int8
-  // and packed int4.
-  for (size_t base_row = 0; base_row < num_rows; base_row += B_ROWS_PER_MMA) {
-    for (int tile_row = 0; tile_row < B_ROWS_PER_MMA; ++tile_row) {
+    // The code is written as below so it works for both int8
+    // and packed int4.
+    for (size_t base_row = 0; base_row < num_rows; base_row += B_ROWS_PER_MMA)
+    {
+        for (int tile_row = 0; tile_row < B_ROWS_PER_MMA; ++tile_row)
+        {
 
-      for (int write_col = 0; write_col < num_vec_cols; ++write_col) {
-        const int write_row = base_row + tile_row;
-        const int tile_read_row = 8 * (((tile_row % ELTS_PER_REG) / 2)) +
-                                  tile_row % 2 + 2 * (tile_row / ELTS_PER_REG);
-        const int read_row = base_row + tile_read_row;
-        const int read_col = write_col;
+            for (int write_col = 0; write_col < num_vec_cols; ++write_col)
+            {
+                const int write_row = base_row + tile_row;
+                const int tile_read_row
+                    = 8 * (((tile_row % ELTS_PER_REG) / 2)) + tile_row % 2 + 2 * (tile_row / ELTS_PER_REG);
+                const int read_row = base_row + tile_read_row;
+                const int read_col = write_col;
 
-        const int64_t read_offset = int64_t(read_row) * num_vec_cols + read_col;
-        const int64_t write_offset =
-            int64_t(write_row) * num_vec_cols + write_col;
+                const int64_t read_offset = int64_t(read_row) * num_vec_cols + read_col;
+                const int64_t write_offset = int64_t(write_row) * num_vec_cols + write_col;
 
-        output_byte_ptr[write_offset] = input_byte_ptr[read_offset];
-      }
+                output_byte_ptr[write_offset] = input_byte_ptr[read_offset];
+            }
+        }
     }
-  }
 }
 
 // We need to use this transpose to correctly handle packed int4 and int8 data
@@ -201,352 +215,360 @@ void permute_B_rows_for_mixed_gemm(int8_t *permuted_quantized_tensor,
 // substantial amount of time to transpose leading to long preprocessing times.
 // This seemed to be a big issue for relatively large models.
 template <QuantType quant_type>
-void subbyte_transpose_impl(int8_t *transposed_quantized_tensor,
-                            const int8_t *quantized_tensor,
-                            const std::vector<size_t> &shape) {
-  const int bits_per_elt = get_bits_in_quant_type(quant_type);
-  const size_t num_rows = shape[0];
-  const size_t num_cols = shape[1];
+void subbyte_transpose_impl(
+    int8_t* transposed_quantized_tensor, const int8_t* quantized_tensor, const std::vector<size_t>& shape)
+{
+    const int bits_per_elt = get_bits_in_quant_type(quant_type);
+    const size_t num_rows = shape[0];
+    const size_t num_cols = shape[1];
 
-  const size_t col_bytes = num_cols * bits_per_elt / 8;
-  const size_t col_bytes_trans = num_rows * bits_per_elt / 8;
+    const size_t col_bytes = num_cols * bits_per_elt / 8;
+    const size_t col_bytes_trans = num_rows * bits_per_elt / 8;
 
-  const uint8_t *input_byte_ptr =
-      reinterpret_cast<const uint8_t *>(quantized_tensor);
-  uint8_t *output_byte_ptr =
-      reinterpret_cast<uint8_t *>(transposed_quantized_tensor);
+    const uint8_t* input_byte_ptr = reinterpret_cast<const uint8_t*>(quantized_tensor);
+    uint8_t* output_byte_ptr = reinterpret_cast<uint8_t*>(transposed_quantized_tensor);
 
-  static constexpr int ELTS_PER_BYTE =
-      quant_type == QuantType::INT8_WEIGHT_ONLY ? 1 : 2;
+    static constexpr int ELTS_PER_BYTE = quant_type == QuantType::INT8_WEIGHT_ONLY ? 1 : 2;
 
-  static constexpr int M_TILE_L1 = 64;
-  static constexpr int N_TILE_L1 = M_TILE_L1 / ELTS_PER_BYTE;
-  uint8_t cache_buf[M_TILE_L1][N_TILE_L1];
+    static constexpr int M_TILE_L1 = 64;
+    static constexpr int N_TILE_L1 = M_TILE_L1 / ELTS_PER_BYTE;
+    uint8_t cache_buf[M_TILE_L1][N_TILE_L1];
 
-  static constexpr int VECTOR_WIDTH = std::min(32, N_TILE_L1);
+    static constexpr int VECTOR_WIDTH = std::min(32, N_TILE_L1);
 
-  // We assume the dims are a multiple of vector width. Our kernels only handle
-  // dims which are multiples of 64 for weight-only quantization. As a result,
-  // this seemed like a reasonable tradeoff because it allows GCC to emit vector
-  // instructions.
-  FT_CHECK_WITH_INFO(
-      !(col_bytes_trans % VECTOR_WIDTH) && !(col_bytes % VECTOR_WIDTH),
-      fmtstr("Number of bytes for rows and cols must be a multiple of %d. "
-             "However, num_rows_bytes = %ld and num_col_bytes = %d.",
-             VECTOR_WIDTH, col_bytes_trans, col_bytes));
+    // We assume the dims are a multiple of vector width. Our kernels only handle
+    // dims which are multiples of 64 for weight-only quantization. As a result,
+    // this seemed like a reasonable tradeoff because it allows GCC to emit vector
+    // instructions.
+    FT_CHECK_WITH_INFO(!(col_bytes_trans % VECTOR_WIDTH) && !(col_bytes % VECTOR_WIDTH),
+        fmtstr("Number of bytes for rows and cols must be a multiple of %d. "
+               "However, num_rows_bytes = %ld and num_col_bytes = %d.",
+            VECTOR_WIDTH, col_bytes_trans, col_bytes));
 
-  for (size_t row_tile_start = 0; row_tile_start < num_rows;
-       row_tile_start += M_TILE_L1) {
-    for (size_t col_tile_start_byte = 0; col_tile_start_byte < col_bytes;
-         col_tile_start_byte += N_TILE_L1) {
+    for (size_t row_tile_start = 0; row_tile_start < num_rows; row_tile_start += M_TILE_L1)
+    {
+        for (size_t col_tile_start_byte = 0; col_tile_start_byte < col_bytes; col_tile_start_byte += N_TILE_L1)
+        {
 
-      const int row_limit = std::min(row_tile_start + M_TILE_L1, num_rows);
-      const int col_limit =
-          std::min(col_tile_start_byte + N_TILE_L1, col_bytes);
+            const int row_limit = std::min(row_tile_start + M_TILE_L1, num_rows);
+            const int col_limit = std::min(col_tile_start_byte + N_TILE_L1, col_bytes);
 
-      for (int ii = 0; ii < M_TILE_L1; ++ii) {
-        const int row = row_tile_start + ii;
+            for (int ii = 0; ii < M_TILE_L1; ++ii)
+            {
+                const int row = row_tile_start + ii;
 
-        for (int jj = 0; jj < N_TILE_L1; jj += VECTOR_WIDTH) {
-          const int col = col_tile_start_byte + jj;
+                for (int jj = 0; jj < N_TILE_L1; jj += VECTOR_WIDTH)
+                {
+                    const int col = col_tile_start_byte + jj;
 
-          const size_t logical_src_offset = row * col_bytes + col;
+                    const size_t logical_src_offset = row * col_bytes + col;
 
-          if (row < row_limit && col < col_limit) {
-            for (int v = 0; v < VECTOR_WIDTH; ++v) {
-              cache_buf[ii][jj + v] = input_byte_ptr[logical_src_offset + v];
+                    if (row < row_limit && col < col_limit)
+                    {
+                        for (int v = 0; v < VECTOR_WIDTH; ++v)
+                        {
+                            cache_buf[ii][jj + v] = input_byte_ptr[logical_src_offset + v];
+                        }
+                    }
+                }
             }
-          }
-        }
-      }
 
-      if (quant_type == QuantType::INT8_WEIGHT_ONLY) {
-        for (int ii = 0; ii < M_TILE_L1; ++ii) {
-          for (int jj = ii + 1; jj < N_TILE_L1; ++jj) {
-            std::swap(cache_buf[ii][jj], cache_buf[jj][ii]);
-          }
-        }
-      } else if (quant_type == QuantType::PACKED_INT4_WEIGHT_ONLY) {
-
-        for (int ii = 0; ii < M_TILE_L1; ++ii) {
-          // Using M_TILE_L1 here is deliberate since we assume that the cache
-          // tile is square in the number of elements (not necessarily the
-          // number of bytes).
-          for (int jj = ii + 1; jj < M_TILE_L1; ++jj) {
-            const int ii_byte = ii / ELTS_PER_BYTE;
-            const int ii_bit_offset = ii % ELTS_PER_BYTE;
-
-            const int jj_byte = jj / ELTS_PER_BYTE;
-            const int jj_bit_offset = jj % ELTS_PER_BYTE;
-
-            uint8_t src_elt =
-                0xF & (cache_buf[ii][jj_byte] >> (4 * jj_bit_offset));
-            uint8_t tgt_elt =
-                0xF & (cache_buf[jj][ii_byte] >> (4 * ii_bit_offset));
-
-            cache_buf[ii][jj_byte] &= (0xF0 >> (4 * jj_bit_offset));
-            cache_buf[jj][ii_byte] &= (0xF0 >> (4 * ii_bit_offset));
-
-            cache_buf[ii][jj_byte] |= (tgt_elt << (4 * jj_bit_offset));
-            cache_buf[jj][ii_byte] |= (src_elt << (4 * ii_bit_offset));
-          }
-        }
-      } else {
-        FT_CHECK_WITH_INFO(false, "Unsupported quantization type.");
-      }
-
-      const size_t row_tile_start_trans = col_tile_start_byte * ELTS_PER_BYTE;
-      const size_t col_tile_start_byte_trans = row_tile_start / ELTS_PER_BYTE;
-
-      const int row_limit_trans =
-          std::min(row_tile_start_trans + M_TILE_L1, num_cols);
-      const int col_limit_trans =
-          std::min(col_tile_start_byte_trans + N_TILE_L1, col_bytes_trans);
-
-      for (int ii = 0; ii < M_TILE_L1; ++ii) {
-        const int row = row_tile_start_trans + ii;
-        for (int jj = 0; jj < N_TILE_L1; jj += VECTOR_WIDTH) {
-          const int col = col_tile_start_byte_trans + jj;
-
-          const size_t logical_tgt_offset = row * col_bytes_trans + col;
-
-          if (row < row_limit_trans && col < col_limit_trans) {
-            for (int v = 0; v < VECTOR_WIDTH; ++v) {
-              output_byte_ptr[logical_tgt_offset + v] = cache_buf[ii][jj + v];
+            if (quant_type == QuantType::INT8_WEIGHT_ONLY)
+            {
+                for (int ii = 0; ii < M_TILE_L1; ++ii)
+                {
+                    for (int jj = ii + 1; jj < N_TILE_L1; ++jj)
+                    {
+                        std::swap(cache_buf[ii][jj], cache_buf[jj][ii]);
+                    }
+                }
             }
-          }
+            else if (quant_type == QuantType::PACKED_INT4_WEIGHT_ONLY)
+            {
+
+                for (int ii = 0; ii < M_TILE_L1; ++ii)
+                {
+                    // Using M_TILE_L1 here is deliberate since we assume that the cache
+                    // tile is square in the number of elements (not necessarily the
+                    // number of bytes).
+                    for (int jj = ii + 1; jj < M_TILE_L1; ++jj)
+                    {
+                        const int ii_byte = ii / ELTS_PER_BYTE;
+                        const int ii_bit_offset = ii % ELTS_PER_BYTE;
+
+                        const int jj_byte = jj / ELTS_PER_BYTE;
+                        const int jj_bit_offset = jj % ELTS_PER_BYTE;
+
+                        uint8_t src_elt = 0xF & (cache_buf[ii][jj_byte] >> (4 * jj_bit_offset));
+                        uint8_t tgt_elt = 0xF & (cache_buf[jj][ii_byte] >> (4 * ii_bit_offset));
+
+                        cache_buf[ii][jj_byte] &= (0xF0 >> (4 * jj_bit_offset));
+                        cache_buf[jj][ii_byte] &= (0xF0 >> (4 * ii_bit_offset));
+
+                        cache_buf[ii][jj_byte] |= (tgt_elt << (4 * jj_bit_offset));
+                        cache_buf[jj][ii_byte] |= (src_elt << (4 * ii_bit_offset));
+                    }
+                }
+            }
+            else
+            {
+                FT_CHECK_WITH_INFO(false, "Unsupported quantization type.");
+            }
+
+            const size_t row_tile_start_trans = col_tile_start_byte * ELTS_PER_BYTE;
+            const size_t col_tile_start_byte_trans = row_tile_start / ELTS_PER_BYTE;
+
+            const int row_limit_trans = std::min(row_tile_start_trans + M_TILE_L1, num_cols);
+            const int col_limit_trans = std::min(col_tile_start_byte_trans + N_TILE_L1, col_bytes_trans);
+
+            for (int ii = 0; ii < M_TILE_L1; ++ii)
+            {
+                const int row = row_tile_start_trans + ii;
+                for (int jj = 0; jj < N_TILE_L1; jj += VECTOR_WIDTH)
+                {
+                    const int col = col_tile_start_byte_trans + jj;
+
+                    const size_t logical_tgt_offset = row * col_bytes_trans + col;
+
+                    if (row < row_limit_trans && col < col_limit_trans)
+                    {
+                        for (int v = 0; v < VECTOR_WIDTH; ++v)
+                        {
+                            output_byte_ptr[logical_tgt_offset + v] = cache_buf[ii][jj + v];
+                        }
+                    }
+                }
+            }
         }
-      }
     }
-  }
 }
 
-void subbyte_transpose(int8_t *transposed_quantized_tensor,
-                       const int8_t *quantized_tensor,
-                       const std::vector<size_t> &shape, QuantType quant_type) {
+void subbyte_transpose(int8_t* transposed_quantized_tensor, const int8_t* quantized_tensor,
+    const std::vector<size_t>& shape, QuantType quant_type)
+{
 
-  if (quant_type == QuantType::INT8_WEIGHT_ONLY) {
-    subbyte_transpose_impl<QuantType::INT8_WEIGHT_ONLY>(
-        transposed_quantized_tensor, quantized_tensor, shape);
-  } else if (quant_type == QuantType::PACKED_INT4_WEIGHT_ONLY) {
-    subbyte_transpose_impl<QuantType::PACKED_INT4_WEIGHT_ONLY>(
-        transposed_quantized_tensor, quantized_tensor, shape);
-  } else {
-    FT_CHECK_WITH_INFO(false, "Invalid quant_tye");
-  }
-}
-
-void add_bias_and_interleave_int8s_inplace(int8_t *int8_tensor,
-                                           const size_t num_elts) {
-  for (size_t ii = 0; ii < num_elts; ++ii) {
-    int8_tensor[ii] = int8_t(int(int8_tensor[ii]) + 128);
-  }
-
-  // Step 2 will transform the layout of a 32-bit register in CUDA in order to
-  // match the int4 layout. This has no performance benefit and is purely so
-  // that int4 and int8 have the same layout. Pictorially, this does the
-  // following: bit 32                                                      0
-  //      [elt_3  elt_2  elt_1  elt_0] (each elt occupies 8 bits)
-  //
-  // And it will rearrange the output 32 bit register to be the following:
-  // bit 32                                                      0
-  //      [elt_3  elt_1  elt_2  elt_0] (each elt occupies 8 bits)
-
-  FT_CHECK_WITH_INFO(num_elts % 4 == 0, "Dimensions of int8 tensor must be a "
-                                        "multiple of 4 for register relayout");
-  for (size_t base = 0; base < num_elts; base += 4) {
-    std::swap(int8_tensor[base + 1], int8_tensor[base + 2]);
-  }
-}
-
-void add_bias_and_interleave_int4s_inplace(int8_t *packed_int4_tensor,
-                                           const size_t num_elts) {
-  const size_t num_bytes = num_elts / 2;
-
-  // Step 1 will be to transform all the int4s to unsigned in order to make the
-  // dequantize take as little instructions as possible in the CUDA code.
-  for (size_t ii = 0; ii < num_bytes; ++ii) {
-    int8_t transformed_packed_int4s = 0;
-    int8_t transformed_first_elt =
-        (int8_t(packed_int4_tensor[ii] << 4) >> 4) +
-        8; // The double shift here is to ensure sign extension
-    int8_t transformed_second_elt = (packed_int4_tensor[ii] >> 4) + 8;
-
-    FT_CHECK_WITH_INFO(transformed_first_elt >= 0 &&
-                           transformed_first_elt <= 15,
-                       "Illegal result for int4 transform (first elt)");
-    FT_CHECK_WITH_INFO(transformed_second_elt >= 0 &&
-                           transformed_second_elt <= 15,
-                       "Illegal result for int4 transform (second elt)");
-
-    // We don't need to mask in these ops since everything should be in the
-    // range 0-15
-    transformed_packed_int4s |= transformed_first_elt;
-    transformed_packed_int4s |= (transformed_second_elt << 4);
-    packed_int4_tensor[ii] = transformed_packed_int4s;
-  }
-
-  // Step 2 will transform the layout of a 32-bit register in CUDA in order to
-  // minimize the number of shift & logical instructions That are needed to
-  // extract the int4s in the GEMM main loop. Pictorially, the loop below will
-  // do the following: Take as input a 32 bit register with layout: bit 32 0
-  //      [elt_7  elt_6  elt_5  elt_4  elt_3  elt_2  elt_1  elt_0] (each elt
-  //      occupies 4 bits)
-  //
-  // And it will rearrange the output 32 bit register to be the following:
-  // bit 32                                                      0
-  //      [elt_7  elt_5  elt_3  elt_1  elt_6  elt_4  elt_2  elt_0] (each elt
-  //      occupies 4 bits)
-
-  FT_CHECK_WITH_INFO(num_bytes % 4 == 0, "Dimensions of int4 tensor must be a "
-                                         "multiple of 8 for register relayout");
-  const size_t num_registers = num_bytes / 4;
-
-  uint32_t *register_ptr = reinterpret_cast<uint32_t *>(packed_int4_tensor);
-  for (size_t ii = 0; ii < num_registers; ++ii) {
-    const uint32_t current_register = register_ptr[ii];
-    uint32_t transformed_register = 0;
-
-    for (int dest_idx = 0; dest_idx < 8; ++dest_idx) {
-      const int src_idx = dest_idx < 4 ? 2 * dest_idx : 2 * (dest_idx - 4) + 1;
-      const int src_shift = 4 * src_idx;
-      const int dest_shift = 4 * dest_idx;
-
-      const uint32_t src_bits = (current_register >> src_shift) & 0xF;
-      transformed_register |= (src_bits << dest_shift);
+    if (quant_type == QuantType::INT8_WEIGHT_ONLY)
+    {
+        subbyte_transpose_impl<QuantType::INT8_WEIGHT_ONLY>(transposed_quantized_tensor, quantized_tensor, shape);
     }
-    register_ptr[ii] = transformed_register;
-  }
-}
-
-void add_bias_and_interleave_quantized_tensor_inplace(int8_t *tensor,
-                                                      const size_t num_elts,
-                                                      QuantType quant_type) {
-  if (quant_type == QuantType::INT8_WEIGHT_ONLY) {
-    add_bias_and_interleave_int8s_inplace(tensor, num_elts);
-  } else if (quant_type == QuantType::PACKED_INT4_WEIGHT_ONLY) {
-    add_bias_and_interleave_int4s_inplace(tensor, num_elts);
-  } else {
-    FT_CHECK_WITH_INFO(false, "Invalid quantization type for interleaving.");
-  }
-}
-
-void interleave_column_major_tensor(int8_t *interleaved_quantized_tensor,
-                                    const int8_t *quantized_tensor,
-                                    const std::vector<size_t> &shape,
-                                    QuantType quant_type,
-                                    LayoutDetails details) {
-  // We only want to run this step for weight only quant.
-  FT_CHECK(quant_type == QuantType::PACKED_INT4_WEIGHT_ONLY ||
-           quant_type == QuantType::INT8_WEIGHT_ONLY);
-  FT_CHECK_WITH_INFO(shape.size() == 2, "Shape must be 2-D");
-
-  const size_t num_rows = shape[0];
-  const size_t num_cols = shape[1];
-
-  const int BITS_PER_ELT = get_bits_in_quant_type(quant_type);
-  const int elts_in_int32 = 32 / BITS_PER_ELT;
-
-  const int rows_per_tile = details.rows_per_column_tile;
-
-  FT_CHECK_WITH_INFO(!(num_rows % elts_in_int32),
-                     fmtstr("The number of rows must be a multiple of %d but "
-                            "the number of rows is %d.",
-                            elts_in_int32, num_rows));
-
-  FT_CHECK_WITH_INFO(!(num_cols % rows_per_tile),
-                     fmtstr("The number of columns must be a multiple of %d "
-                            "but the number of columns is %ld",
-                            rows_per_tile, num_cols));
-
-  const uint32_t *input_byte_ptr =
-      reinterpret_cast<const uint32_t *>(quantized_tensor);
-  uint32_t *output_byte_ptr =
-      reinterpret_cast<uint32_t *>(interleaved_quantized_tensor);
-
-  FT_CHECK_WITH_INFO(!(num_cols % rows_per_tile),
-                     fmtstr("The number of columns must be a multiple of %d "
-                            "but the number of columns is %d.",
-                            rows_per_tile, num_cols));
-
-  const int num_vec_rows = num_rows / elts_in_int32;
-  const int vec_rows_per_tile = rows_per_tile / elts_in_int32;
-  const int interleave = details.columns_interleaved;
-
-  for (size_t read_col = 0; read_col < num_cols; ++read_col) {
-    const auto write_col = read_col / interleave;
-    for (int base_vec_row = 0; base_vec_row < num_vec_rows;
-         base_vec_row += vec_rows_per_tile) {
-      for (int vec_read_row = base_vec_row;
-           vec_read_row <
-           std::min(num_vec_rows, base_vec_row + vec_rows_per_tile);
-           ++vec_read_row) {
-        const int64_t vec_write_row =
-            interleave * base_vec_row +
-            vec_rows_per_tile * (read_col % interleave) +
-            vec_read_row % vec_rows_per_tile;
-
-        const int64_t read_offset =
-            int64_t(read_col) * num_vec_rows + vec_read_row;
-        const int64_t write_offset =
-            int64_t(write_col) * num_vec_rows * interleave + vec_write_row;
-        output_byte_ptr[write_offset] = input_byte_ptr[read_offset];
-      }
+    else if (quant_type == QuantType::PACKED_INT4_WEIGHT_ONLY)
+    {
+        subbyte_transpose_impl<QuantType::PACKED_INT4_WEIGHT_ONLY>(
+            transposed_quantized_tensor, quantized_tensor, shape);
     }
-  }
+    else
+    {
+        FT_CHECK_WITH_INFO(false, "Invalid quant_tye");
+    }
 }
 
-void preprocess_weights_for_mixed_gemm(int8_t *preprocessed_quantized_weight,
-                                       const int8_t *row_major_quantized_weight,
-                                       const std::vector<size_t> &shape,
-                                       QuantType quant_type, int arch) {
-  LayoutDetails details = getLayoutDetailsForTransform(quant_type, arch);
+void add_bias_and_interleave_int8s_inplace(int8_t* int8_tensor, const size_t num_elts)
+{
+    for (size_t ii = 0; ii < num_elts; ++ii)
+    {
+        int8_tensor[ii] = int8_t(int(int8_tensor[ii]) + 128);
+    }
 
-  FT_CHECK_WITH_INFO(shape.size() == 2, "Shape must be 2-D");
+    // Step 2 will transform the layout of a 32-bit register in CUDA in order to
+    // match the int4 layout. This has no performance benefit and is purely so
+    // that int4 and int8 have the same layout. Pictorially, this does the
+    // following: bit 32                                                      0
+    //      [elt_3  elt_2  elt_1  elt_0] (each elt occupies 8 bits)
+    //
+    // And it will rearrange the output 32 bit register to be the following:
+    // bit 32                                                      0
+    //      [elt_3  elt_1  elt_2  elt_0] (each elt occupies 8 bits)
 
-  size_t num_elts = 1;
-  for (const auto &dim : shape) {
-    num_elts *= dim;
-  }
-
-  const size_t num_bytes = num_elts * get_bits_in_quant_type(quant_type) / 8;
-
-  std::vector<int8_t> src_buf(num_bytes);
-  std::vector<int8_t> dst_buf(num_bytes);
-  std::copy(row_major_quantized_weight, row_major_quantized_weight + num_bytes,
-            src_buf.begin());
-
-  // Works on row major data, so issue this permutation first.
-  if (details.uses_imma_ldsm) {
-    permute_B_rows_for_mixed_gemm(dst_buf.data(), src_buf.data(), shape,
-                                  quant_type, arch);
-    src_buf.swap(dst_buf);
-  }
-
-  if (details.layoutB == LayoutDetails::Layout::COLUMN_MAJOR) {
-    subbyte_transpose(dst_buf.data(), src_buf.data(), shape, quant_type);
-    src_buf.swap(dst_buf);
-  }
-
-  if (details.columns_interleaved > 1) {
-    interleave_column_major_tensor(dst_buf.data(), src_buf.data(), shape,
-                                   quant_type, details);
-    src_buf.swap(dst_buf);
-  }
-
-  add_bias_and_interleave_quantized_tensor_inplace(src_buf.data(), num_elts,
-                                                   quant_type);
-  std::copy(src_buf.begin(), src_buf.end(), preprocessed_quantized_weight);
+    FT_CHECK_WITH_INFO(num_elts % 4 == 0,
+        "Dimensions of int8 tensor must be a "
+        "multiple of 4 for register relayout");
+    for (size_t base = 0; base < num_elts; base += 4)
+    {
+        std::swap(int8_tensor[base + 1], int8_tensor[base + 2]);
+    }
 }
 
-void preprocess_weights(int8_t *preprocessed_quantized_weight,
-                        const int8_t *row_major_quantized_weight, size_t rows,
-                        size_t cols, bool is_int4, int arch) {
-  QuantType qtype = is_int4 ? QuantType::PACKED_INT4_WEIGHT_ONLY
-                            : QuantType::INT8_WEIGHT_ONLY;
-  preprocess_weights_for_mixed_gemm(preprocessed_quantized_weight,
-                                    row_major_quantized_weight, {rows, cols},
-                                    qtype, arch);
+void add_bias_and_interleave_int4s_inplace(int8_t* packed_int4_tensor, const size_t num_elts)
+{
+    const size_t num_bytes = num_elts / 2;
+
+    // Step 1 will be to transform all the int4s to unsigned in order to make the
+    // dequantize take as little instructions as possible in the CUDA code.
+    for (size_t ii = 0; ii < num_bytes; ++ii)
+    {
+        int8_t transformed_packed_int4s = 0;
+        int8_t transformed_first_elt
+            = (int8_t(packed_int4_tensor[ii] << 4) >> 4) + 8; // The double shift here is to ensure sign extension
+        int8_t transformed_second_elt = (packed_int4_tensor[ii] >> 4) + 8;
+
+        FT_CHECK_WITH_INFO(
+            transformed_first_elt >= 0 && transformed_first_elt <= 15, "Illegal result for int4 transform (first elt)");
+        FT_CHECK_WITH_INFO(transformed_second_elt >= 0 && transformed_second_elt <= 15,
+            "Illegal result for int4 transform (second elt)");
+
+        // We don't need to mask in these ops since everything should be in the
+        // range 0-15
+        transformed_packed_int4s |= transformed_first_elt;
+        transformed_packed_int4s |= (transformed_second_elt << 4);
+        packed_int4_tensor[ii] = transformed_packed_int4s;
+    }
+
+    // Step 2 will transform the layout of a 32-bit register in CUDA in order to
+    // minimize the number of shift & logical instructions That are needed to
+    // extract the int4s in the GEMM main loop. Pictorially, the loop below will
+    // do the following: Take as input a 32 bit register with layout: bit 32 0
+    //      [elt_7  elt_6  elt_5  elt_4  elt_3  elt_2  elt_1  elt_0] (each elt
+    //      occupies 4 bits)
+    //
+    // And it will rearrange the output 32 bit register to be the following:
+    // bit 32                                                      0
+    //      [elt_7  elt_5  elt_3  elt_1  elt_6  elt_4  elt_2  elt_0] (each elt
+    //      occupies 4 bits)
+
+    FT_CHECK_WITH_INFO(num_bytes % 4 == 0,
+        "Dimensions of int4 tensor must be a "
+        "multiple of 8 for register relayout");
+    const size_t num_registers = num_bytes / 4;
+
+    uint32_t* register_ptr = reinterpret_cast<uint32_t*>(packed_int4_tensor);
+    for (size_t ii = 0; ii < num_registers; ++ii)
+    {
+        const uint32_t current_register = register_ptr[ii];
+        uint32_t transformed_register = 0;
+
+        for (int dest_idx = 0; dest_idx < 8; ++dest_idx)
+        {
+            const int src_idx = dest_idx < 4 ? 2 * dest_idx : 2 * (dest_idx - 4) + 1;
+            const int src_shift = 4 * src_idx;
+            const int dest_shift = 4 * dest_idx;
+
+            const uint32_t src_bits = (current_register >> src_shift) & 0xF;
+            transformed_register |= (src_bits << dest_shift);
+        }
+        register_ptr[ii] = transformed_register;
+    }
+}
+
+void add_bias_and_interleave_quantized_tensor_inplace(int8_t* tensor, const size_t num_elts, QuantType quant_type)
+{
+    if (quant_type == QuantType::INT8_WEIGHT_ONLY)
+    {
+        add_bias_and_interleave_int8s_inplace(tensor, num_elts);
+    }
+    else if (quant_type == QuantType::PACKED_INT4_WEIGHT_ONLY)
+    {
+        add_bias_and_interleave_int4s_inplace(tensor, num_elts);
+    }
+    else
+    {
+        FT_CHECK_WITH_INFO(false, "Invalid quantization type for interleaving.");
+    }
+}
+
+void interleave_column_major_tensor(int8_t* interleaved_quantized_tensor, const int8_t* quantized_tensor,
+    const std::vector<size_t>& shape, QuantType quant_type, LayoutDetails details)
+{
+    // We only want to run this step for weight only quant.
+    FT_CHECK(quant_type == QuantType::PACKED_INT4_WEIGHT_ONLY || quant_type == QuantType::INT8_WEIGHT_ONLY);
+    FT_CHECK_WITH_INFO(shape.size() == 2, "Shape must be 2-D");
+
+    const size_t num_rows = shape[0];
+    const size_t num_cols = shape[1];
+
+    const int BITS_PER_ELT = get_bits_in_quant_type(quant_type);
+    const int elts_in_int32 = 32 / BITS_PER_ELT;
+
+    const int rows_per_tile = details.rows_per_column_tile;
+
+    FT_CHECK_WITH_INFO(!(num_rows % elts_in_int32),
+        fmtstr("The number of rows must be a multiple of %d but "
+               "the number of rows is %d.",
+            elts_in_int32, num_rows));
+
+    FT_CHECK_WITH_INFO(!(num_cols % rows_per_tile),
+        fmtstr("The number of columns must be a multiple of %d "
+               "but the number of columns is %ld",
+            rows_per_tile, num_cols));
+
+    const uint32_t* input_byte_ptr = reinterpret_cast<const uint32_t*>(quantized_tensor);
+    uint32_t* output_byte_ptr = reinterpret_cast<uint32_t*>(interleaved_quantized_tensor);
+
+    FT_CHECK_WITH_INFO(!(num_cols % rows_per_tile),
+        fmtstr("The number of columns must be a multiple of %d "
+               "but the number of columns is %d.",
+            rows_per_tile, num_cols));
+
+    const int num_vec_rows = num_rows / elts_in_int32;
+    const int vec_rows_per_tile = rows_per_tile / elts_in_int32;
+    const int interleave = details.columns_interleaved;
+
+    for (size_t read_col = 0; read_col < num_cols; ++read_col)
+    {
+        const auto write_col = read_col / interleave;
+        for (int base_vec_row = 0; base_vec_row < num_vec_rows; base_vec_row += vec_rows_per_tile)
+        {
+            for (int vec_read_row = base_vec_row;
+                 vec_read_row < std::min(num_vec_rows, base_vec_row + vec_rows_per_tile); ++vec_read_row)
+            {
+                const int64_t vec_write_row = interleave * base_vec_row + vec_rows_per_tile * (read_col % interleave)
+                    + vec_read_row % vec_rows_per_tile;
+
+                const int64_t read_offset = int64_t(read_col) * num_vec_rows + vec_read_row;
+                const int64_t write_offset = int64_t(write_col) * num_vec_rows * interleave + vec_write_row;
+                output_byte_ptr[write_offset] = input_byte_ptr[read_offset];
+            }
+        }
+    }
+}
+
+void preprocess_weights_for_mixed_gemm(int8_t* preprocessed_quantized_weight, const int8_t* row_major_quantized_weight,
+    const std::vector<size_t>& shape, QuantType quant_type, int arch)
+{
+    LayoutDetails details = getLayoutDetailsForTransform(quant_type, arch);
+
+    FT_CHECK_WITH_INFO(shape.size() == 2, "Shape must be 2-D");
+
+    size_t num_elts = 1;
+    for (const auto& dim : shape)
+    {
+        num_elts *= dim;
+    }
+
+    const size_t num_bytes = num_elts * get_bits_in_quant_type(quant_type) / 8;
+
+    std::vector<int8_t> src_buf(num_bytes);
+    std::vector<int8_t> dst_buf(num_bytes);
+    std::copy(row_major_quantized_weight, row_major_quantized_weight + num_bytes, src_buf.begin());
+
+    // Works on row major data, so issue this permutation first.
+    if (details.uses_imma_ldsm)
+    {
+        permute_B_rows_for_mixed_gemm(dst_buf.data(), src_buf.data(), shape, quant_type, arch);
+        src_buf.swap(dst_buf);
+    }
+
+    if (details.layoutB == LayoutDetails::Layout::COLUMN_MAJOR)
+    {
+        subbyte_transpose(dst_buf.data(), src_buf.data(), shape, quant_type);
+        src_buf.swap(dst_buf);
+    }
+
+    if (details.columns_interleaved > 1)
+    {
+        interleave_column_major_tensor(dst_buf.data(), src_buf.data(), shape, quant_type, details);
+        src_buf.swap(dst_buf);
+    }
+
+    add_bias_and_interleave_quantized_tensor_inplace(src_buf.data(), num_elts, quant_type);
+    std::copy(src_buf.begin(), src_buf.end(), preprocessed_quantized_weight);
+}
+
+void preprocess_weights(int8_t* preprocessed_quantized_weight, const int8_t* row_major_quantized_weight, size_t rows,
+    size_t cols, bool is_int4, int arch)
+{
+    QuantType qtype = is_int4 ? QuantType::PACKED_INT4_WEIGHT_ONLY : QuantType::INT8_WEIGHT_ONLY;
+    preprocess_weights_for_mixed_gemm(
+        preprocessed_quantized_weight, row_major_quantized_weight, {rows, cols}, qtype, arch);
 }
 
 } // namespace fastertransformer

--- a/cutlass_kernels/cutlass_preprocessors.h
+++ b/cutlass_kernels/cutlass_preprocessors.h
@@ -4,10 +4,10 @@
 #include <cstddef>
 #include <cstdint>
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
-void preprocess_weights(int8_t *preprocessed_quantized_weight,
-                        const int8_t *row_major_quantized_weight, size_t rows,
-                        size_t cols, bool is_int4, int arch);
+void preprocess_weights(int8_t* preprocessed_quantized_weight, const int8_t* row_major_quantized_weight, size_t rows,
+    size_t cols, bool is_int4, int arch);
 
 } // namespace fastertransformer

--- a/cutlass_kernels/fpA_intB_gemm.h
+++ b/cutlass_kernels/fpA_intB_gemm.h
@@ -1,36 +1,34 @@
 #pragma once
 
-#include <string>
 #include <optional>
+#include <string>
 
-#include <cuda_runtime.h>
-#include "cutlass/numeric_types.h"
 #include "cutlass/half.h"
+// clang-format off
+#include "cutlass/numeric_types.h"
 #include "cutlass/integer_subbyte.h"
+// clang-format on
+#include <cuda_runtime.h>
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
 using half = cutlass::half_t;
 using uint4b_t = cutlass::uint4b_t;
 
-void preprocess_weights(int8_t *preprocessed_quantized_weight,
-                        const int8_t *row_major_quantized_weight, size_t rows,
-                        size_t cols, bool is_int4, int arch);
+void preprocess_weights(int8_t* preprocessed_quantized_weight, const int8_t* row_major_quantized_weight, size_t rows,
+    size_t cols, bool is_int4, int arch);
 
 // TODO: Support more general bias shape
 
 template <typename WeightType>
-void gemm_fp16_int_bias_act(const half *A, const WeightType *B,
-			    const half *weight_scales, const half *bias,
-			    half *C, std::optional<std::string> activation, int m,
-			    int n, int k, int bias_stride, char *workspace_ptr,
-			    size_t workspace_bytes, cudaStream_t stream);
+void gemm_fp16_int_bias_act(const half* A, const WeightType* B, const half* weight_scales, const half* bias, half* C,
+    std::optional<std::string> activation, int m, int n, int k, int bias_stride, char* workspace_ptr,
+    size_t workspace_bytes, cudaStream_t stream);
 
 template <typename WeightType>
-void gemm_fp16_int_bias_act_residual(
-    const half *A, const WeightType *B, const half *weight_scales,
-    const half *bias, const half *residual, half *C, const std::string& activation, const std::string& binary_op,
-    const std::string& unary_op, int m, int n, int k, char *workspace_ptr, size_t workspace_bytes, cudaStream_t stream);
-
+void gemm_fp16_int_bias_act_residual(const half* A, const WeightType* B, const half* weight_scales, const half* bias,
+    const half* residual, half* C, const std::string& activation, const std::string& binary_op,
+    const std::string& unary_op, int m, int n, int k, char* workspace_ptr, size_t workspace_bytes, cudaStream_t stream);
 
 } // namespace fastertransformer

--- a/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm.h
+++ b/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm.h
@@ -20,7 +20,8 @@
 #include "utils/activation_types.h"
 #include <cuda_runtime_api.h>
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
 /*
   This runner only supports:
@@ -34,79 +35,36 @@ namespace fastertransformer {
   modifications to mix_gemm_B_layout.h.
 */
 
-template<typename T, typename WeightType>
-class CutlassFpAIntBGemmRunner {
+template <typename T, typename WeightType>
+class CutlassFpAIntBGemmRunner
+{
 public:
     CutlassFpAIntBGemmRunner();
     ~CutlassFpAIntBGemmRunner();
 
-    void gemm(const T*          A,
-              const WeightType* B,
-              const T*          weight_scales,
-              T*                C,
-              int               m,
-              int               n,
-              int               k,
-              char*             workspace_ptr,
-              const size_t      workspace_bytes,
-              cudaStream_t      stream);
+    void gemm(const T* A, const WeightType* B, const T* weight_scales, T* C, int m, int n, int k, char* workspace_ptr,
+        const size_t workspace_bytes, cudaStream_t stream);
 
-    void gemm_bias_act(const T*          A,
-                       const WeightType* B,
-                       const T*          weight_scales,
-                       const T*          biases,
-                       T*                C,
-                       int               m,
-                       int               n,
-                       int               k,
-		       int bias_stride,
-                       ActivationType    activation_type,
-                       char*             workspace_ptr,
-                       const size_t      workspace_bytes,
-                       cudaStream_t      stream);
+    void gemm_bias_act(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
+        int k, int bias_stride, ActivationType activation_type, char* workspace_ptr, const size_t workspace_bytes,
+        cudaStream_t stream);
 
-    void gemm_bias_act_residual(const T *A, const WeightType *B,
-                                const T *weight_scales, const T *biases,
-                                const T *residual, T *C, int m, int n, int k,
-				const std::string& activation, const std::string& binary_op,
-				const std::string& unary_op,
-                                char *workspace_ptr,
-                                const size_t workspace_bytes,
-                                cudaStream_t stream);
+    void gemm_bias_act_residual(const T* A, const WeightType* B, const T* weight_scales, const T* biases,
+        const T* residual, T* C, int m, int n, int k, const std::string& activation, const std::string& binary_op,
+        const std::string& unary_op, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream);
 
     // Returns desired workspace size in bytes.
     int getWorkspaceSize(const int m, const int n, const int k);
 
 private:
-    template<typename EpilogueTag>
-    void dispatch_to_arch(const T*          A,
-                          const WeightType* B,
-                          const T*          weight_scales,
-                          const T*          biases,
-                          T*                C,
-                          int               m,
-                          int               n,
-                          int               k,
-  		          int bias_stride,
-                          CutlassGemmConfig gemm_config,
-                          char*             workspace_ptr,
-                          const size_t      workspace_bytes,
-                          cudaStream_t      stream,
-                          int*              occupancy = nullptr);
+    template <typename EpilogueTag>
+    void dispatch_to_arch(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
+        int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace_ptr, const size_t workspace_bytes,
+        cudaStream_t stream, int* occupancy = nullptr);
 
-    template<typename EpilogueTag>
-    void run_gemm(const T*          A,
-                  const WeightType* B,
-                  const T*          weight_scales,
-                  const T*          biases,
-                  T*                C,
-                  int               m,
-                  int               n,
-                  int               k,
-		  int bias_stride,
-                  char*             workspace_ptr,
-                  const size_t      workspace_bytes,
-                  cudaStream_t      stream);
+    template <typename EpilogueTag>
+    void run_gemm(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n, int k,
+        int bias_stride, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream);
 
 private:
     static constexpr int split_k_limit = 7;
@@ -115,4 +73,4 @@ private:
     int multi_processor_count_;
 };
 
-}  // namespace fastertransformer
+} // namespace fastertransformer

--- a/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm_template.h
+++ b/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm_template.h
@@ -17,10 +17,10 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 
+#include "cutlass/epilogue/thread/linear_combination_residual_block.h"
 #include "cutlass/gemm/device/gemm_universal_base.h"
 #include "cutlass/gemm/kernel/default_gemm.h"
 #include "cutlass/gemm/kernel/default_gemm_with_broadcast.h"
-#include "cutlass/epilogue/thread/linear_combination_residual_block.h"
 #include "cutlass_extensions/compute_occupancy.h"
 
 #include "cutlass_extensions/epilogue_helpers.h"
@@ -33,107 +33,76 @@
 #pragma GCC diagnostic pop
 
 #include "../cutlass_heuristic.h"
-#include "fpA_intB_gemm.h"
 #include "cuda_utils.h"
+#include "fpA_intB_gemm.h"
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
-template<typename T,
-         typename WeightType,
-         typename arch,
-         typename EpilogueTag,
-         typename ThreadblockShape,
-         typename WarpShape,
-         int Stages>
-void generic_mixed_gemm_kernelLauncher(const T*          A,
-                                       const WeightType* B,
-                                       const T*          weight_scales,
-                                       const T*          biases,
-                                       T*                C,
-                                       int               m,
-                                       int               n,
-                                       int               k,
-				       int bias_stride,
-                                       CutlassGemmConfig gemm_config,
-                                       char*             workspace,
-                                       size_t            workspace_bytes,
-                                       cudaStream_t      stream,
-                                       int*              occupancy = nullptr)
+template <typename T, typename WeightType, typename arch, typename EpilogueTag, typename ThreadblockShape,
+    typename WarpShape, int Stages>
+void generic_mixed_gemm_kernelLauncher(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C,
+    int m, int n, int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
+    cudaStream_t stream, int* occupancy = nullptr)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
     static_assert(cutlass::platform::is_same<T, half>::value || cutlass::platform::is_same<T, float>::value,
-                  "Specialized for half, float");
+        "Specialized for half, float");
 
     static_assert(cutlass::platform::is_same<T, WeightType>::value
-                      || cutlass::platform::is_same<WeightType, uint8_t>::value
-                      || cutlass::platform::is_same<WeightType, cutlass::uint4b_t>::value,
-                  "");
+            || cutlass::platform::is_same<WeightType, uint8_t>::value
+            || cutlass::platform::is_same<WeightType, cutlass::uint4b_t>::value,
+        "");
 
     // The cutlass type for the input elements. This is needed to convert to cutlass::half_t if necessary.
     using ElementType_ =
         typename cutlass::platform::conditional<cutlass::platform::is_same<T, half>::value, cutlass::half_t, T>::type;
-    using ElementType       = ElementType_;
+    using ElementType = ElementType_;
 
-    using CutlassWeightType_ = typename cutlass::platform::
-        conditional<cutlass::platform::is_same<WeightType, half>::value, cutlass::half_t, WeightType>::type;
+    using CutlassWeightType_ =
+        typename cutlass::platform::conditional<cutlass::platform::is_same<WeightType, half>::value, cutlass::half_t,
+            WeightType>::type;
     using CutlassWeightType = CutlassWeightType_;
 
     // We need separate config for each architecture since we will target different tensorcore instructions. For float,
     // we do not target TCs.
     using MixedGemmArchTraits = cutlass::gemm::kernel::MixedGemmArchTraits<ElementType, CutlassWeightType, arch>;
-    using ElementAccumulator  = typename MixedGemmArchTraits::AccType;
+    using ElementAccumulator = typename MixedGemmArchTraits::AccType;
 
     using EpilogueOp =
         typename Epilogue<ElementType, MixedGemmArchTraits::ElementsPerAccessC, ElementAccumulator, EpilogueTag>::Op;
 
-    using GemmKernel_ = typename cutlass::gemm::kernel::DefaultGemm<
-        ElementType,
-        cutlass::layout::RowMajor,
-        MixedGemmArchTraits::ElementsPerAccessA,
-        CutlassWeightType,
-        typename MixedGemmArchTraits::LayoutB,
-        MixedGemmArchTraits::ElementsPerAccessB,
-        ElementType,
-        cutlass::layout::RowMajor,
-        ElementAccumulator,
-        cutlass::arch::OpClassTensorOp,
-        arch,
-        ThreadblockShape,
-        WarpShape,
-        typename MixedGemmArchTraits::InstructionShape,
-        EpilogueOp,
-        typename cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>,
-        Stages,
-        true,
+    using GemmKernel_ = typename cutlass::gemm::kernel::DefaultGemm<ElementType, cutlass::layout::RowMajor,
+        MixedGemmArchTraits::ElementsPerAccessA, CutlassWeightType, typename MixedGemmArchTraits::LayoutB,
+        MixedGemmArchTraits::ElementsPerAccessB, ElementType, cutlass::layout::RowMajor, ElementAccumulator,
+        cutlass::arch::OpClassTensorOp, arch, ThreadblockShape, WarpShape,
+        typename MixedGemmArchTraits::InstructionShape, EpilogueOp,
+        typename cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, Stages, true,
         typename MixedGemmArchTraits::Operator>::GemmKernel;
 
-    using GemmKernel = cutlass::gemm::kernel::GemmFpAIntB<typename GemmKernel_::Mma,
-                                                          typename GemmKernel_::Epilogue,
-                                                          typename GemmKernel_::ThreadblockSwizzle,
-                                                          arch,  // Ensure top level arch is used for dispatch
-                                                          GemmKernel_::kSplitKSerial>;
+    using GemmKernel = cutlass::gemm::kernel::GemmFpAIntB<typename GemmKernel_::Mma, typename GemmKernel_::Epilogue,
+        typename GemmKernel_::ThreadblockSwizzle,
+        arch, // Ensure top level arch is used for dispatch
+        GemmKernel_::kSplitKSerial>;
 
-    if (occupancy != nullptr) {
+    if (occupancy != nullptr)
+    {
         *occupancy = compute_occupancy_for_kernel<GemmKernel>();
         return;
     }
 
     using Gemm = cutlass::gemm::device::GemmUniversalBase<GemmKernel>;
 
-    const int ldb =
-        cutlass::platform::is_same<cutlass::layout::RowMajor, typename MixedGemmArchTraits::LayoutB>::value ?
-            n :
-            k * GemmKernel::kInterleave;
+    const int ldb = cutlass::platform::is_same<cutlass::layout::RowMajor, typename MixedGemmArchTraits::LayoutB>::value
+        ? n
+        : k * GemmKernel::kInterleave;
 
-    typename Gemm::Arguments args({m, n, k},
-                                  {reinterpret_cast<ElementType*>(const_cast<T*>(A)), k},
-                                  {reinterpret_cast<CutlassWeightType*>(const_cast<WeightType*>(B)), ldb},
-                                  {reinterpret_cast<ElementType*>(const_cast<T*>(weight_scales)), 0},
-				  // TODO: Support more general bias shape
-                                  {reinterpret_cast<ElementType*>(const_cast<T*>(biases)), bias_stride},
-                                  {reinterpret_cast<ElementType*>(C), n},
-                                  gemm_config.split_k_factor,
-                                  {ElementAccumulator(1.f), ElementAccumulator(0.f)});
+    typename Gemm::Arguments args({m, n, k}, {reinterpret_cast<ElementType*>(const_cast<T*>(A)), k},
+        {reinterpret_cast<CutlassWeightType*>(const_cast<WeightType*>(B)), ldb},
+        {reinterpret_cast<ElementType*>(const_cast<T*>(weight_scales)), 0},
+        // TODO: Support more general bias shape
+        {reinterpret_cast<ElementType*>(const_cast<T*>(biases)), bias_stride}, {reinterpret_cast<ElementType*>(C), n},
+        gemm_config.split_k_factor, {ElementAccumulator(1.f), ElementAccumulator(0.f)});
 
     // This assertion is enabled because because for the column interleaved layout, K MUST be a multiple of
     // threadblockK. The reason for this is that the default pitchlinear iterators are used to handle walking over the
@@ -141,12 +110,14 @@ void generic_mixed_gemm_kernelLauncher(const T*          A,
     // our own predicated iterator in order to relax this limitation.
     if (GemmKernel::kInterleave > 1
         && ((k % MixedGemmArchTraits::ThreadblockK)
-            || ((k / gemm_config.split_k_factor) % MixedGemmArchTraits::ThreadblockK))) {
+            || ((k / gemm_config.split_k_factor) % MixedGemmArchTraits::ThreadblockK)))
+    {
         throw std::runtime_error("Temp assertion: k must be multiple of threadblockK");
     }
 
     Gemm gemm;
-    if (gemm.get_workspace_size(args) > workspace_bytes) {
+    if (gemm.get_workspace_size(args) > workspace_bytes)
+    {
         FT_LOG_WARNING(
             "Requested split-k but workspace size insufficient. Falling back to non-split-k implementation.");
         // If requested split-k factor will require more workspace bytes, revert to standard gemm.
@@ -154,192 +125,114 @@ void generic_mixed_gemm_kernelLauncher(const T*          A,
     }
 
     auto can_implement = gemm.can_implement(args);
-    if (can_implement != cutlass::Status::kSuccess) {
+    if (can_implement != cutlass::Status::kSuccess)
+    {
         std::string err_msg = "fpA_intB cutlass kernel will fail for params. Error: "
-                              + std::string(cutlassGetStatusString(can_implement));
+            + std::string(cutlassGetStatusString(can_implement));
         throw std::runtime_error("[FT Error][fpA_intB Runner] " + err_msg);
     }
 
     auto init_status = gemm.initialize(args, workspace, stream);
-    if (init_status != cutlass::Status::kSuccess) {
-        std::string err_msg =
-            "Failed to initialize cutlass fpA_intB gemm. Error: " + std::string(cutlassGetStatusString(init_status));
+    if (init_status != cutlass::Status::kSuccess)
+    {
+        std::string err_msg
+            = "Failed to initialize cutlass fpA_intB gemm. Error: " + std::string(cutlassGetStatusString(init_status));
         throw std::runtime_error("[FT Error][fpA_intB Runner] " + err_msg);
     }
 
     auto run_status = gemm.run(stream);
-    if (run_status != cutlass::Status::kSuccess) {
-        std::string err_msg =
-            "Failed to run cutlass fpA_intB gemm. Error: " + std::string(cutlassGetStatusString(run_status));
+    if (run_status != cutlass::Status::kSuccess)
+    {
+        std::string err_msg
+            = "Failed to run cutlass fpA_intB gemm. Error: " + std::string(cutlassGetStatusString(run_status));
         throw std::runtime_error("[FT Error][fpA_intB Runner] " + err_msg);
     }
 }
 
-template<typename T,
-         typename WeightType,
-         typename arch,
-         typename EpilogueTag,
-         typename ThreadblockShape,
-         typename WarpShape,
-         int Stages,
-         typename Enable = void>
-struct dispatch_stages {
-    static void dispatch(const T*          A,
-                         const WeightType* B,
-                         const T*          weight_scales,
-                         const T*          biases,
-                         T*                C,
-                         int               m,
-                         int               n,
-                         int               k,
-			 int bias_stride,
-                         CutlassGemmConfig gemm_config,
-                         char*             workspace,
-                         size_t            workspace_bytes,
-                         cudaStream_t      stream,
-                         int*              occupancy = nullptr)
+template <typename T, typename WeightType, typename arch, typename EpilogueTag, typename ThreadblockShape,
+    typename WarpShape, int Stages, typename Enable = void>
+struct dispatch_stages
+{
+    static void dispatch(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
+        int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
+        cudaStream_t stream, int* occupancy = nullptr)
     {
 
         FT_LOG_DEBUG(__PRETTY_FUNCTION__);
         std::string err_msg = "Cutlass fpA_intB gemm. Not instantiates for arch "
-                              + std::to_string(arch::kMinComputeCapability) + " with stages set to "
-                              + std::to_string(Stages);
+            + std::to_string(arch::kMinComputeCapability) + " with stages set to " + std::to_string(Stages);
         throw std::runtime_error("[FT Error][dispatch_stages::dispatch] " + err_msg);
     }
 };
 
-template<typename T,
-         typename WeightType,
-         typename arch,
-         typename EpilogueTag,
-         typename ThreadblockShape,
-         typename WarpShape>
-struct dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 2> {
-    static void dispatch(const T*          A,
-                         const WeightType* B,
-                         const T*          weight_scales,
-                         const T*          biases,
-                         T*                C,
-                         int               m,
-                         int               n,
-                         int               k,
-			 int bias_stride,
-                         CutlassGemmConfig gemm_config,
-                         char*             workspace,
-                         size_t            workspace_bytes,
-                         cudaStream_t      stream,
-                         int*              occupancy = nullptr)
+template <typename T, typename WeightType, typename arch, typename EpilogueTag, typename ThreadblockShape,
+    typename WarpShape>
+struct dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 2>
+{
+    static void dispatch(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
+        int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
+        cudaStream_t stream, int* occupancy = nullptr)
     {
 
         FT_LOG_DEBUG(__PRETTY_FUNCTION__);
-        generic_mixed_gemm_kernelLauncher<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 2>(
-													    A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes, stream, occupancy);
+        generic_mixed_gemm_kernelLauncher<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 2>(A, B,
+            weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes, stream, occupancy);
     }
 };
 
-template<typename T,
-         typename WeightType,
-         typename EpilogueTag,
-         typename ThreadblockShape,
-         typename WarpShape,
-         int Stages>
-struct dispatch_stages<T,
-                       WeightType,
-                       cutlass::arch::Sm80,
-                       EpilogueTag,
-                       ThreadblockShape,
-                       WarpShape,
-                       Stages,
-                       typename std::enable_if<(Stages > 2)>::type> {
-    static void dispatch(const T*          A,
-                         const WeightType* B,
-                         const T*          weight_scales,
-                         const T*          biases,
-                         T*                C,
-                         int               m,
-                         int               n,
-                         int               k,
-			 int bias_stride,
-                         CutlassGemmConfig gemm_config,
-                         char*             workspace,
-                         size_t            workspace_bytes,
-                         cudaStream_t      stream,
-                         int*              occupancy = nullptr)
+template <typename T, typename WeightType, typename EpilogueTag, typename ThreadblockShape, typename WarpShape,
+    int Stages>
+struct dispatch_stages<T, WeightType, cutlass::arch::Sm80, EpilogueTag, ThreadblockShape, WarpShape, Stages,
+    typename std::enable_if<(Stages > 2)>::type>
+{
+    static void dispatch(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
+        int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
+        cudaStream_t stream, int* occupancy = nullptr)
     {
 
         FT_LOG_DEBUG(__PRETTY_FUNCTION__);
-        generic_mixed_gemm_kernelLauncher<T,
-                                          WeightType,
-                                          cutlass::arch::Sm80,
-                                          EpilogueTag,
-                                          ThreadblockShape,
-                                          WarpShape,
-                                          Stages>(
-	  A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes, stream, occupancy);
+        generic_mixed_gemm_kernelLauncher<T, WeightType, cutlass::arch::Sm80, EpilogueTag, ThreadblockShape, WarpShape,
+            Stages>(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes,
+            stream, occupancy);
     }
 };
 
-template<typename T,
-         typename WeightType,
-         typename arch,
-         typename EpilogueTag,
-         typename ThreadblockShape,
-         typename WarpShape>
-void dispatch_gemm_config(const T*          A,
-                          const WeightType* B,
-                          const T*          weight_scales,
-                          const T*          biases,
-                          T*                C,
-                          int               m,
-                          int               n,
-                          int               k,
-   			  int bias_stride,
-                          CutlassGemmConfig gemm_config,
-                          char*             workspace,
-                          size_t            workspace_bytes,
-                          cudaStream_t      stream,
-                          int*              occupancy = nullptr)
+template <typename T, typename WeightType, typename arch, typename EpilogueTag, typename ThreadblockShape,
+    typename WarpShape>
+void dispatch_gemm_config(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
+    int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes, cudaStream_t stream,
+    int* occupancy = nullptr)
 {
 
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
-    switch (gemm_config.stages) {
-        case 2:
-            using DispatcherStages2 = dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 2>;
-            DispatcherStages2::dispatch(
-   	        A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes, stream, occupancy);
-            break;
-        case 3:
-            using DispatcherStages3 = dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 3>;
-            DispatcherStages3::dispatch(
-   	        A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes, stream, occupancy);
-            break;
-        case 4:
-            using DispatcherStages4 = dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 4>;
-            DispatcherStages4::dispatch(
-	        A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes, stream, occupancy);
-            break;
-        default:
-            std::string err_msg = "dispatch_gemm_config does not support stages " + std::to_string(gemm_config.stages);
-            throw std::runtime_error("[FT Error][dispatch_gemm_config] " + err_msg);
-            break;
+    switch (gemm_config.stages)
+    {
+    case 2:
+        using DispatcherStages2 = dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 2>;
+        DispatcherStages2::dispatch(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace,
+            workspace_bytes, stream, occupancy);
+        break;
+    case 3:
+        using DispatcherStages3 = dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 3>;
+        DispatcherStages3::dispatch(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace,
+            workspace_bytes, stream, occupancy);
+        break;
+    case 4:
+        using DispatcherStages4 = dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 4>;
+        DispatcherStages4::dispatch(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace,
+            workspace_bytes, stream, occupancy);
+        break;
+    default:
+        std::string err_msg = "dispatch_gemm_config does not support stages " + std::to_string(gemm_config.stages);
+        throw std::runtime_error("[FT Error][dispatch_gemm_config] " + err_msg);
+        break;
     }
 }
 
-template<typename T, typename WeightType, typename arch, typename EpilogueTag>
-void dispatch_gemm_to_cutlass(const T*          A,
-                              const WeightType* B,
-                              const T*          weight_scales,
-                              const T*          biases,
-                              T*                C,
-                              int               m,
-                              int               n,
-                              int               k,
-               		      int bias_stride,
-                              char*             workspace,
-                              size_t            workspace_bytes,
-                              CutlassGemmConfig gemm_config,
-                              cudaStream_t      stream,
-                              int*              occupancy = nullptr)
+template <typename T, typename WeightType, typename arch, typename EpilogueTag>
+void dispatch_gemm_to_cutlass(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m,
+    int n, int k, int bias_stride, char* workspace, size_t workspace_bytes, CutlassGemmConfig gemm_config,
+    cudaStream_t stream, int* occupancy = nullptr)
 {
 
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
@@ -347,49 +240,38 @@ void dispatch_gemm_to_cutlass(const T*          A,
     // Note that SIMT configs are omitted here since they are not supported for fpA_intB.
     // We also only instantiate configs here where threadblockShapeM == warpShapeM since those usually perform the best
     // for mixed type gemms.
-    switch (gemm_config.tile_config) {
-        case CutlassTileConfig::CtaShape32x128x64_WarpShape32x32x64:
-            dispatch_gemm_config<T,
-                                 WeightType,
-                                 arch,
-                                 EpilogueTag,
-                                 cutlass::gemm::GemmShape<32, 128, 64>,
-                                 cutlass::gemm::GemmShape<32, 32, 64>>(
-                A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes, stream, occupancy);
-            break;
-        case CutlassTileConfig::CtaShape64x128x64_WarpShape64x32x64:
-            dispatch_gemm_config<T,
-                                 WeightType,
-                                 arch,
-                                 EpilogueTag,
-                                 cutlass::gemm::GemmShape<64, 128, 64>,
-                                 cutlass::gemm::GemmShape<64, 32, 64>>(
-                A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes, stream, occupancy);
-	    break;
-        case CutlassTileConfig::CtaShape128x128x64_WarpShape128x32x64:
-            dispatch_gemm_config<T,
-                                 WeightType,
-                                 arch,
-                                 EpilogueTag,
-                                 cutlass::gemm::GemmShape<128, 128, 64>,
-                                 cutlass::gemm::GemmShape<128, 32, 64>>(
-                A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes, stream, occupancy);
-            break;
-        case CutlassTileConfig::Undefined:
-            throw std::runtime_error("[FT Error][fpA_intB][dispatch_gemm_to_cutlass] gemm config undefined.");
-            break;
-        case CutlassTileConfig::ChooseWithHeuristic:
-            throw std::runtime_error(
-                "[FT Error][fpA_intB][dispatch_gemm_to_cutlass] gemm config should have already been set by heuristic.");
-            break;
-        default:
-            throw std::runtime_error(
-                "[FT Error][fpA_intB][dispatch_gemm_to_cutlass] Config is invalid for mixed type GEMM.");
-            break;
+    switch (gemm_config.tile_config)
+    {
+    case CutlassTileConfig::CtaShape32x128x64_WarpShape32x32x64:
+        dispatch_gemm_config<T, WeightType, arch, EpilogueTag, cutlass::gemm::GemmShape<32, 128, 64>,
+            cutlass::gemm::GemmShape<32, 32, 64>>(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config,
+            workspace, workspace_bytes, stream, occupancy);
+        break;
+    case CutlassTileConfig::CtaShape64x128x64_WarpShape64x32x64:
+        dispatch_gemm_config<T, WeightType, arch, EpilogueTag, cutlass::gemm::GemmShape<64, 128, 64>,
+            cutlass::gemm::GemmShape<64, 32, 64>>(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config,
+            workspace, workspace_bytes, stream, occupancy);
+        break;
+    case CutlassTileConfig::CtaShape128x128x64_WarpShape128x32x64:
+        dispatch_gemm_config<T, WeightType, arch, EpilogueTag, cutlass::gemm::GemmShape<128, 128, 64>,
+            cutlass::gemm::GemmShape<128, 32, 64>>(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config,
+            workspace, workspace_bytes, stream, occupancy);
+        break;
+    case CutlassTileConfig::Undefined:
+        throw std::runtime_error("[FT Error][fpA_intB][dispatch_gemm_to_cutlass] gemm config undefined.");
+        break;
+    case CutlassTileConfig::ChooseWithHeuristic:
+        throw std::runtime_error(
+            "[FT Error][fpA_intB][dispatch_gemm_to_cutlass] gemm config should have already been set by heuristic.");
+        break;
+    default:
+        throw std::runtime_error(
+            "[FT Error][fpA_intB][dispatch_gemm_to_cutlass] Config is invalid for mixed type GEMM.");
+        break;
     }
 }
 
-template<typename T, typename WeightType>
+template <typename T, typename WeightType>
 CutlassFpAIntBGemmRunner<T, WeightType>::CutlassFpAIntBGemmRunner()
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
@@ -399,453 +281,376 @@ CutlassFpAIntBGemmRunner<T, WeightType>::CutlassFpAIntBGemmRunner()
     check_cuda_error(cudaDeviceGetAttribute(&multi_processor_count_, cudaDevAttrMultiProcessorCount, device));
 }
 
-template<typename T, typename WeightType>
+template <typename T, typename WeightType>
 CutlassFpAIntBGemmRunner<T, WeightType>::~CutlassFpAIntBGemmRunner()
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
 }
 
-template<typename T, typename WeightType>
-template<typename EpilogueTag>
-void CutlassFpAIntBGemmRunner<T, WeightType>::dispatch_to_arch<EpilogueTag>(const T*          A,
-                                                                            const WeightType* B,
-                                                                            const T*          weight_scales,
-                                                                            const T*          biases,
-                                                                            T*                C,
-                                                                            int               m,
-                                                                            int               n,
-                                                                            int               k,
-									    int bias_stride,
-                                                                            CutlassGemmConfig gemm_config,
-                                                                            char*             workspace_ptr,
-                                                                            const size_t      workspace_bytes,
-                                                                            cudaStream_t      stream,
-                                                                            int*              occupancy)
+template <typename T, typename WeightType>
+template <typename EpilogueTag>
+void CutlassFpAIntBGemmRunner<T, WeightType>::dispatch_to_arch<EpilogueTag>(const T* A, const WeightType* B,
+    const T* weight_scales, const T* biases, T* C, int m, int n, int k, int bias_stride, CutlassGemmConfig gemm_config,
+    char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream, int* occupancy)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
-    if (sm_ >= 70 && sm_ < 75) {
-        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm70, EpilogueTag>(
-	    A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
-    } else if (sm_ >= 75 && sm_ < 80) {
-        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm75, EpilogueTag>(
-	    A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
-    } else if (sm_ >= 80 && sm_ < 90) {
-        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm80, EpilogueTag>(
-	    A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
+    if (sm_ >= 70 && sm_ < 75)
+    {
+        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm70, EpilogueTag>(A, B, weight_scales, biases, C, m, n,
+            k, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
     }
-    else {
+    else if (sm_ >= 75 && sm_ < 80)
+    {
+        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm75, EpilogueTag>(A, B, weight_scales, biases, C, m, n,
+            k, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
+    }
+    else if (sm_ >= 80 && sm_ < 90)
+    {
+        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm80, EpilogueTag>(A, B, weight_scales, biases, C, m, n,
+            k, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
+    }
+    else
+    {
         throw std::runtime_error(
             "[FT Error][CutlassFpAIntBGemmRunner][GEMM Dispatch] Arch unsupported for CUTLASS mixed type GEMM");
     }
 }
 
-template<typename T, typename WeightType>
-template<typename EpilogueTag>
-void CutlassFpAIntBGemmRunner<T, WeightType>::run_gemm<EpilogueTag>(const T*          A,
-                                                                    const WeightType* B,
-                                                                    const T*          weight_scales,
-                                                                    const T*          biases,
-                                                                    T*                C,
-                                                                    int               m,
-                                                                    int               n,
-                                                                    int               k,
-								    int bias_stride,
-                                                                    char*             workspace_ptr,
-                                                                    const size_t      workspace_bytes,
-                                                                    cudaStream_t      stream)
+template <typename T, typename WeightType>
+template <typename EpilogueTag>
+void CutlassFpAIntBGemmRunner<T, WeightType>::run_gemm<EpilogueTag>(const T* A, const WeightType* B,
+    const T* weight_scales, const T* biases, T* C, int m, int n, int k, int bias_stride, char* workspace_ptr,
+    const size_t workspace_bytes, cudaStream_t stream)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
-    static constexpr bool          is_weight_only    = !std::is_same<T, WeightType>::value;
+    static constexpr bool is_weight_only = !std::is_same<T, WeightType>::value;
     std::vector<CutlassGemmConfig> candidate_configs = get_candidate_configs(sm_, is_weight_only, false);
-    std::vector<int>               occupancies(candidate_configs.size());
+    std::vector<int> occupancies(candidate_configs.size());
 
-    for (size_t ii = 0; ii < candidate_configs.size(); ++ii) {
-        dispatch_to_arch<EpilogueTag>(A,
-                                      B,
-                                      weight_scales,
-                                      biases,
-                                      C,
-                                      m,
-                                      n,
-                                      k,
-				      bias_stride,
-                                      candidate_configs[ii],
-                                      workspace_ptr,
-                                      workspace_bytes,
-                                      stream,
-                                      &occupancies[ii]);
+    for (size_t ii = 0; ii < candidate_configs.size(); ++ii)
+    {
+        dispatch_to_arch<EpilogueTag>(A, B, weight_scales, biases, C, m, n, k, bias_stride, candidate_configs[ii],
+            workspace_ptr, workspace_bytes, stream, &occupancies[ii]);
     }
     // Standard GEMM, so 1 "expert". We use the same function for MoE and regular FFN.
-    static constexpr int num_experts   = 1;
-    CutlassGemmConfig    chosen_config = estimate_best_config_from_occupancies(candidate_configs,
-                                                                            occupancies,
-                                                                            m,
-                                                                            n,
-                                                                            k,
-                                                                            num_experts,
-                                                                            split_k_limit,
-                                                                            workspace_bytes,
-                                                                            multi_processor_count_,
-                                                                            is_weight_only);
+    static constexpr int num_experts = 1;
+    CutlassGemmConfig chosen_config = estimate_best_config_from_occupancies(candidate_configs, occupancies, m, n, k,
+        num_experts, split_k_limit, workspace_bytes, multi_processor_count_, is_weight_only);
 
     dispatch_to_arch<EpilogueTag>(
         A, B, weight_scales, biases, C, m, n, k, bias_stride, chosen_config, workspace_ptr, workspace_bytes, stream);
 }
 
-template<typename T, typename WeightType>
-void CutlassFpAIntBGemmRunner<T, WeightType>::gemm_bias_act(const T*          A,
-                                                            const WeightType* B,
-                                                            const T*          weight_scales,
-                                                            const T*          biases,
-                                                            T*                C,
-                                                            int               m,
-                                                            int               n,
-                                                            int               k,
-							    int bias_stride,
-                                                            ActivationType    activation_type,
-                                                            char*             workspace_ptr,
-                                                            const size_t      workspace_bytes,
-                                                            cudaStream_t      stream)
+template <typename T, typename WeightType>
+void CutlassFpAIntBGemmRunner<T, WeightType>::gemm_bias_act(const T* A, const WeightType* B, const T* weight_scales,
+    const T* biases, T* C, int m, int n, int k, int bias_stride, ActivationType activation_type, char* workspace_ptr,
+    const size_t workspace_bytes, cudaStream_t stream)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
 
-    switch (activation_type) {
-        case ActivationType::Relu:
-            run_gemm<EpilogueOpBiasReLU>(
-   	        A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
-            break;
-        case ActivationType::Gelu:
-            run_gemm<EpilogueOpBiasFtGelu>(
-   	        A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
-            break;
-        case ActivationType::Silu:
-            run_gemm<EpilogueOpBiasSilu>(
-   	        A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
-            break;
-        case ActivationType::Identity:
-   	    run_gemm<EpilogueOpBias>(A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
-            break;
-        case ActivationType::InvalidType:
-            FT_CHECK_WITH_INFO(false, "Activation type for fpA_intB must be valid.");
-            break;
-        default: {
-            if (isGatedActivation(activation_type)) {
-                FT_CHECK_WITH_INFO(false, "Fused gated activations not supported");
-            }
-            else {
-                FT_CHECK_WITH_INFO(false, "Invalid activation type.");
-            }
+    switch (activation_type)
+    {
+    case ActivationType::Relu:
+        run_gemm<EpilogueOpBiasReLU>(
+            A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
+        break;
+    case ActivationType::Gelu:
+        run_gemm<EpilogueOpBiasFtGelu>(
+            A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
+        break;
+    case ActivationType::Silu:
+        run_gemm<EpilogueOpBiasSilu>(
+            A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
+        break;
+    case ActivationType::Identity:
+        run_gemm<EpilogueOpBias>(
+            A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
+        break;
+    case ActivationType::InvalidType: FT_CHECK_WITH_INFO(false, "Activation type for fpA_intB must be valid."); break;
+    default:
+    {
+        if (isGatedActivation(activation_type))
+        {
+            FT_CHECK_WITH_INFO(false, "Fused gated activations not supported");
         }
+        else
+        {
+            FT_CHECK_WITH_INFO(false, "Invalid activation type.");
+        }
+    }
     }
 }
 
-template<typename T, typename WeightType>
-void CutlassFpAIntBGemmRunner<T, WeightType>::gemm(const T*          A,
-                                                   const WeightType* B,
-                                                   const T*          weight_scales,
-                                                   T*                C,
-                                                   int               m,
-                                                   int               n,
-                                                   int               k,
-                                                   char*             workspace_ptr,
-                                                   const size_t      workspace_bytes,
-                                                   cudaStream_t      stream)
+template <typename T, typename WeightType>
+void CutlassFpAIntBGemmRunner<T, WeightType>::gemm(const T* A, const WeightType* B, const T* weight_scales, T* C, int m,
+    int n, int k, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
     run_gemm<EpilogueOpNoBias>(A, B, weight_scales, nullptr, C, m, n, k, 0, workspace_ptr, workspace_bytes, stream);
 }
 
-template <typename T, typename WeightType, typename Arch,
-          typename ThreadblockShape, typename WarpShape, typename EpilogueOp,
-          int stages>
-void dispatch_gemm_residual(const T *A, const WeightType *B,
-                            const T *weight_scales, const T *biases,
-                            const T *residual, T *C, int m, int n, int k,
-                            char *workspace_ptr, const size_t workspace_bytes,
-                            cudaStream_t stream) {
-  using ElementType = typename cutlass::platform::conditional<
-      cutlass::platform::is_same<T, half>::value, cutlass::half_t, T>::type;
-  using ElementOutput = ElementType;
+template <typename T, typename WeightType, typename Arch, typename ThreadblockShape, typename WarpShape,
+    typename EpilogueOp, int stages>
+void dispatch_gemm_residual(const T* A, const WeightType* B, const T* weight_scales, const T* biases, const T* residual,
+    T* C, int m, int n, int k, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream)
+{
+    using ElementType =
+        typename cutlass::platform::conditional<cutlass::platform::is_same<T, half>::value, cutlass::half_t, T>::type;
+    using ElementOutput = ElementType;
 
-  using MixedGemmArchTraits =
-      cutlass::gemm::kernel::MixedGemmArchTraits<ElementType, WeightType, Arch>;
-  using ElementAccumulator = typename EpilogueOp::ElementAccumulator;
+    using MixedGemmArchTraits = cutlass::gemm::kernel::MixedGemmArchTraits<ElementType, WeightType, Arch>;
+    using ElementAccumulator = typename EpilogueOp::ElementAccumulator;
 
-  using Swizzle =
-      typename cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>;
-  using InstructionShape = typename MixedGemmArchTraits::InstructionShape;
+    using Swizzle = typename cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>;
+    using InstructionShape = typename MixedGemmArchTraits::InstructionShape;
 
-  using Epilogue = typename cutlass::gemm::kernel::DefaultGemmWithBroadcast<
-      ElementType, cutlass::layout::RowMajor, cutlass::ComplexTransform::kNone,
-      MixedGemmArchTraits::ElementsPerAccessA, WeightType,
-      typename MixedGemmArchTraits::LayoutB, cutlass::ComplexTransform::kNone,
-      MixedGemmArchTraits::ElementsPerAccessB, ElementType,
-      cutlass::layout::RowMajor, ElementAccumulator,
-      cutlass::arch::OpClassTensorOp, Arch, ThreadblockShape, WarpShape,
-      InstructionShape, EpilogueOp, Swizzle, stages,
-      typename MixedGemmArchTraits::Operator>::Epilogue;
+    using Epilogue = typename cutlass::gemm::kernel::DefaultGemmWithBroadcast<ElementType, cutlass::layout::RowMajor,
+        cutlass::ComplexTransform::kNone, MixedGemmArchTraits::ElementsPerAccessA, WeightType,
+        typename MixedGemmArchTraits::LayoutB, cutlass::ComplexTransform::kNone,
+        MixedGemmArchTraits::ElementsPerAccessB, ElementType, cutlass::layout::RowMajor, ElementAccumulator,
+        cutlass::arch::OpClassTensorOp, Arch, ThreadblockShape, WarpShape, InstructionShape, EpilogueOp, Swizzle,
+        stages, typename MixedGemmArchTraits::Operator>::Epilogue;
 
-  using GemmKernel_ = typename cutlass::gemm::kernel::DefaultGemm<
-      ElementType, cutlass::layout::RowMajor,
-      MixedGemmArchTraits::ElementsPerAccessA, WeightType,
-      typename MixedGemmArchTraits::LayoutB,
-      MixedGemmArchTraits::ElementsPerAccessB, ElementType,
-      cutlass::layout::RowMajor, ElementAccumulator,
-      cutlass::arch::OpClassTensorOp, Arch, ThreadblockShape, WarpShape,
-      InstructionShape, EpilogueOp, Swizzle, stages, true,
-      typename MixedGemmArchTraits::Operator>::GemmKernel;
+    using GemmKernel_ = typename cutlass::gemm::kernel::DefaultGemm<ElementType, cutlass::layout::RowMajor,
+        MixedGemmArchTraits::ElementsPerAccessA, WeightType, typename MixedGemmArchTraits::LayoutB,
+        MixedGemmArchTraits::ElementsPerAccessB, ElementType, cutlass::layout::RowMajor, ElementAccumulator,
+        cutlass::arch::OpClassTensorOp, Arch, ThreadblockShape, WarpShape, InstructionShape, EpilogueOp, Swizzle,
+        stages, true, typename MixedGemmArchTraits::Operator>::GemmKernel;
 
-  using GemmKernel = cutlass::gemm::kernel::GemmFpAIntBWithBroadcast<
-      typename GemmKernel_::Mma, Epilogue,
-      typename GemmKernel_::ThreadblockSwizzle, Arch>;
+    using GemmKernel = cutlass::gemm::kernel::GemmFpAIntBWithBroadcast<typename GemmKernel_::Mma, Epilogue,
+        typename GemmKernel_::ThreadblockSwizzle, Arch>;
 
-  using Gemm = cutlass::gemm::device::GemmUniversalBase<GemmKernel>;
+    using Gemm = cutlass::gemm::device::GemmUniversalBase<GemmKernel>;
 
-  // TODO: Support batch
-  const int batch_count = 1;
-  const auto lda = k;
-  const int ldb =
-      cutlass::platform::is_same<cutlass::layout::RowMajor,
-                                 typename MixedGemmArchTraits::LayoutB>::value
-          ? n
-          : k * GemmKernel::kInterleave;
-  const int ldc = n;
+    // TODO: Support batch
+    const int batch_count = 1;
+    const auto lda = k;
+    const int ldb = cutlass::platform::is_same<cutlass::layout::RowMajor, typename MixedGemmArchTraits::LayoutB>::value
+        ? n
+        : k * GemmKernel::kInterleave;
+    const int ldc = n;
 
-  typename Gemm::Arguments args(
-      {m, n, k}, batch_count,
-      {ElementAccumulator(1.f), ElementAccumulator(1.f)}, A, B, weight_scales,
-      residual, C, biases, nullptr, 0, 0, 0, 0, 0, 0, lda, ldb, ldc, ldc, 0, 0);
+    typename Gemm::Arguments args({m, n, k}, batch_count, {ElementAccumulator(1.f), ElementAccumulator(1.f)}, A, B,
+        weight_scales, residual, C, biases, nullptr, 0, 0, 0, 0, 0, 0, lda, ldb, ldc, ldc, 0, 0);
 
-  if (GemmKernel::kInterleave > 1 &&
-      ((k % MixedGemmArchTraits::ThreadblockK) ||
-       (k % MixedGemmArchTraits::ThreadblockK))) {
-    throw std::runtime_error(
-        "Temp assertion: k must be multiple of threadblockK");
-  }
+    if (GemmKernel::kInterleave > 1
+        && ((k % MixedGemmArchTraits::ThreadblockK) || (k % MixedGemmArchTraits::ThreadblockK)))
+    {
+        throw std::runtime_error("Temp assertion: k must be multiple of threadblockK");
+    }
 
-  Gemm gemm;
-  auto can_implement = gemm.can_implement(args);
-  if (can_implement != cutlass::Status::kSuccess) {
-    std::string err_msg =
-        "fpA_intB cutlass kernel will fail for params. Error: " +
-        std::string(cutlassGetStatusString(can_implement));
-    throw std::runtime_error("[FT Error][fpA_intB Runner] " + err_msg);
-  }
+    Gemm gemm;
+    auto can_implement = gemm.can_implement(args);
+    if (can_implement != cutlass::Status::kSuccess)
+    {
+        std::string err_msg = "fpA_intB cutlass kernel will fail for params. Error: "
+            + std::string(cutlassGetStatusString(can_implement));
+        throw std::runtime_error("[FT Error][fpA_intB Runner] " + err_msg);
+    }
 
-  auto init_status = gemm.initialize(args, workspace_ptr, stream);
-  if (init_status != cutlass::Status::kSuccess) {
-    std::string err_msg =
-        "Failed to initialize cutlass fpA_intB gemm. Error: " +
-        std::string(cutlassGetStatusString(init_status));
-    throw std::runtime_error("[FT Error][fpA_intB Runner] " + err_msg);
-  }
+    auto init_status = gemm.initialize(args, workspace_ptr, stream);
+    if (init_status != cutlass::Status::kSuccess)
+    {
+        std::string err_msg
+            = "Failed to initialize cutlass fpA_intB gemm. Error: " + std::string(cutlassGetStatusString(init_status));
+        throw std::runtime_error("[FT Error][fpA_intB Runner] " + err_msg);
+    }
 
-  auto run_status = gemm.run(stream);
-  if (run_status != cutlass::Status::kSuccess) {
-    std::string err_msg = "Failed to run cutlass fpA_intB gemm. Error: " +
-                          std::string(cutlassGetStatusString(run_status));
-    throw std::runtime_error("[FT Error][fpA_intB Runner] " + err_msg);
-  }
+    auto run_status = gemm.run(stream);
+    if (run_status != cutlass::Status::kSuccess)
+    {
+        std::string err_msg
+            = "Failed to run cutlass fpA_intB gemm. Error: " + std::string(cutlassGetStatusString(run_status));
+        throw std::runtime_error("[FT Error][fpA_intB Runner] " + err_msg);
+    }
 }
 
-template <typename T, typename WeightType, typename Arch, typename EpilogueOp,
-          int stages>
-void dispatch_gemm_residual(CutlassTileConfig tile_config, const T *A,
-                            const WeightType *B, const T *weight_scales,
-                            const T *biases, const T *residual, T *C, int m,
-                            int n, int k, char *workspace_ptr,
-                            const size_t workspace_bytes, cudaStream_t stream) {
-  if (tile_config == CutlassTileConfig::CtaShape32x128x64_WarpShape32x32x64) {
-    dispatch_gemm_residual<
-        T, WeightType, Arch, cutlass::gemm::GemmShape<32, 128, 64>,
-        cutlass::gemm::GemmShape<32, 32, 64>, EpilogueOp, stages>(
-        A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr,
-        workspace_bytes, stream);
-  } else if (tile_config ==
-             CutlassTileConfig::CtaShape64x128x64_WarpShape64x32x64) {
-    dispatch_gemm_residual<
-        T, WeightType, Arch, cutlass::gemm::GemmShape<64, 128, 64>,
-        cutlass::gemm::GemmShape<64, 32, 64>, EpilogueOp, stages>(
-        A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr,
-        workspace_bytes, stream);
-  } else { // CutlassTileConfig::CtaShape128x128x64_WarpShape128x32x64:
-    dispatch_gemm_residual<
-        T, WeightType, Arch, cutlass::gemm::GemmShape<128, 128, 64>,
-        cutlass::gemm::GemmShape<128, 32, 64>, EpilogueOp, stages>(
-        A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr,
-        workspace_bytes, stream);
-  }
+template <typename T, typename WeightType, typename Arch, typename EpilogueOp, int stages>
+void dispatch_gemm_residual(CutlassTileConfig tile_config, const T* A, const WeightType* B, const T* weight_scales,
+    const T* biases, const T* residual, T* C, int m, int n, int k, char* workspace_ptr, const size_t workspace_bytes,
+    cudaStream_t stream)
+{
+    if (tile_config == CutlassTileConfig::CtaShape32x128x64_WarpShape32x32x64)
+    {
+        dispatch_gemm_residual<T, WeightType, Arch, cutlass::gemm::GemmShape<32, 128, 64>,
+            cutlass::gemm::GemmShape<32, 32, 64>, EpilogueOp, stages>(
+            A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+    }
+    else if (tile_config == CutlassTileConfig::CtaShape64x128x64_WarpShape64x32x64)
+    {
+        dispatch_gemm_residual<T, WeightType, Arch, cutlass::gemm::GemmShape<64, 128, 64>,
+            cutlass::gemm::GemmShape<64, 32, 64>, EpilogueOp, stages>(
+            A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+    }
+    else
+    { // CutlassTileConfig::CtaShape128x128x64_WarpShape128x32x64:
+        dispatch_gemm_residual<T, WeightType, Arch, cutlass::gemm::GemmShape<128, 128, 64>,
+            cutlass::gemm::GemmShape<128, 32, 64>, EpilogueOp, stages>(
+            A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+    }
 }
 
 template <typename T, typename WeightType, typename Arch, typename EpilogueOp>
-void dispatch_gemm_residual(CutlassGemmConfig config, const T *A,
-                            const WeightType *B, const T *weight_scales,
-                            const T *biases, const T *residual, T *C, int m,
-                            int n, int k, char *workspace_ptr,
-                            const size_t workspace_bytes, cudaStream_t stream) {
-  if constexpr (std::is_same<Arch, cutlass::arch::Sm75>::value) {
-    dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm75, EpilogueOp, 2>(
-        config.tile_config, A, B, weight_scales, biases, residual, C, m, n, k,
-        workspace_ptr, workspace_bytes, stream);
-  } else if constexpr (std::is_same<Arch, cutlass::arch::Sm70>::value) {
-    dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm70, EpilogueOp, 2>(
-        config.tile_config, A, B, weight_scales, biases, residual, C, m, n, k,
-        workspace_ptr, workspace_bytes, stream);
-  } else {
-    if (config.stages == 3) {
-      dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp, 3>(
-          config.tile_config, A, B, weight_scales, biases, residual, C, m, n, k,
-          workspace_ptr, workspace_bytes, stream);
-    } else if (config.stages == 4) {
-      dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp, 4>(
-          config.tile_config, A, B, weight_scales, biases, residual, C, m, n, k,
-          workspace_ptr, workspace_bytes, stream);
-    } else { // 2
-      dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp, 2>(
-          config.tile_config, A, B, weight_scales, biases, residual, C, m, n, k,
-          workspace_ptr, workspace_bytes, stream);
+void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const WeightType* B, const T* weight_scales,
+    const T* biases, const T* residual, T* C, int m, int n, int k, char* workspace_ptr, const size_t workspace_bytes,
+    cudaStream_t stream)
+{
+    if constexpr (std::is_same<Arch, cutlass::arch::Sm75>::value)
+    {
+        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm75, EpilogueOp, 2>(config.tile_config, A, B,
+            weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
     }
-  }
+    else if constexpr (std::is_same<Arch, cutlass::arch::Sm70>::value)
+    {
+        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm70, EpilogueOp, 2>(config.tile_config, A, B,
+            weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+    }
+    else
+    {
+        if (config.stages == 3)
+        {
+            dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp, 3>(config.tile_config, A, B, weight_scales, biases,
+                residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+        }
+        else if (config.stages == 4)
+        {
+            dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp, 4>(config.tile_config, A, B, weight_scales, biases,
+                residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+        }
+        else
+        { // 2
+            dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp, 2>(config.tile_config, A, B, weight_scales, biases,
+                residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+        }
+    }
 }
 
-template <typename T, typename WeightType, typename Arch,
-          template <typename T_> class ActivationOp,
-          template <typename T_> class BinaryOp>
-inline void
-dispatch_gemm_residual(CutlassGemmConfig config, const T *A,
-                       const WeightType *B, const T *weight_scales,
-                       const T *biases, const T *residual, T *C, int m, int n,
-                       int k, const std::string &unary_op, char *workspace_ptr,
-                       const size_t workspace_bytes, cudaStream_t stream) {
-  using ElementOutput = T;
-  using MixedGemmArchTraits =
-      cutlass::gemm::kernel::MixedGemmArchTraits<T, WeightType, Arch>;
-  using ElementAccumulator = typename MixedGemmArchTraits::AccType;
+template <typename T, typename WeightType, typename Arch, template <typename T_> class ActivationOp,
+    template <typename T_> class BinaryOp>
+inline void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const WeightType* B, const T* weight_scales,
+    const T* biases, const T* residual, T* C, int m, int n, int k, const std::string& unary_op, char* workspace_ptr,
+    const size_t workspace_bytes, cudaStream_t stream)
+{
+    using ElementOutput = T;
+    using MixedGemmArchTraits = cutlass::gemm::kernel::MixedGemmArchTraits<T, WeightType, Arch>;
+    using ElementAccumulator = typename MixedGemmArchTraits::AccType;
 
-  if (unary_op == "identity") {
-    using EpilogueOp =
-        cutlass::epilogue::thread::LinearCombinationResidualBlock<
-            ElementOutput, ElementAccumulator, ElementAccumulator,
-            ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
-            ActivationOp, BinaryOp, cutlass::epilogue::thread::Identity>;
-    dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp>(
-        config, A, B, weight_scales, biases, residual, C, m, n, k,
-        workspace_ptr, workspace_bytes, stream);
-  } else if (unary_op == "relu") {
-    using EpilogueOp =
-        cutlass::epilogue::thread::LinearCombinationResidualBlock<
-            ElementOutput, ElementAccumulator, ElementAccumulator,
-            ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value,
-            ActivationOp, BinaryOp, cutlass::epilogue::thread::ReLu>;
-    dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp>(
-        config, A, B, weight_scales, biases, residual, C, m, n, k,
-        workspace_ptr, workspace_bytes, stream);
-  } else {
-    throw std::runtime_error(
-        "[FT Error][Unsupported unary op after residual block] " + unary_op);
-  }
+    if (unary_op == "identity")
+    {
+        using EpilogueOp = cutlass::epilogue::thread::LinearCombinationResidualBlock<ElementOutput, ElementAccumulator,
+            ElementAccumulator, ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value, ActivationOp, BinaryOp,
+            cutlass::epilogue::thread::Identity>;
+        dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp>(
+            config, A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+    }
+    else if (unary_op == "relu")
+    {
+        using EpilogueOp = cutlass::epilogue::thread::LinearCombinationResidualBlock<ElementOutput, ElementAccumulator,
+            ElementAccumulator, ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value, ActivationOp, BinaryOp,
+            cutlass::epilogue::thread::ReLu>;
+        dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp>(
+            config, A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+    }
+    else
+    {
+        throw std::runtime_error("[FT Error][Unsupported unary op after residual block] " + unary_op);
+    }
 }
 
-template <typename T, typename WeightType, typename Arch,
-          template <typename T_> class ActivationOp>
-void dispatch_gemm_residual(CutlassGemmConfig config, const T *A,
-                            const WeightType *B, const T *weight_scales,
-                            const T *biases, const T *residual, T *C, int m,
-                            int n, int k, const std::string &binary_op,
-                            const std::string &unary_op, char *workspace_ptr,
-                            const size_t workspace_bytes, cudaStream_t stream) {
-  if (binary_op == "plus") {
-    dispatch_gemm_residual<T, WeightType, Arch, ActivationOp, cutlass::plus>(
-        config, A, B, weight_scales, biases, residual, C, m, n, k, unary_op,
-        workspace_ptr, workspace_bytes, stream);
-  } else if (binary_op == "multiply") {
-    dispatch_gemm_residual<T, WeightType, Arch, ActivationOp,
-                           cutlass::multiplies>(
-        config, A, B, weight_scales, biases, residual, C, m, n, k, unary_op,
-        workspace_ptr, workspace_bytes, stream);
-  } else {
-    throw std::runtime_error(
-        "[FT Error][Unsupported binary op for residual block] " + binary_op);
-  }
+template <typename T, typename WeightType, typename Arch, template <typename T_> class ActivationOp>
+void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const WeightType* B, const T* weight_scales,
+    const T* biases, const T* residual, T* C, int m, int n, int k, const std::string& binary_op,
+    const std::string& unary_op, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream)
+{
+    if (binary_op == "plus")
+    {
+        dispatch_gemm_residual<T, WeightType, Arch, ActivationOp, cutlass::plus>(config, A, B, weight_scales, biases,
+            residual, C, m, n, k, unary_op, workspace_ptr, workspace_bytes, stream);
+    }
+    else if (binary_op == "multiply")
+    {
+        dispatch_gemm_residual<T, WeightType, Arch, ActivationOp, cutlass::multiplies>(config, A, B, weight_scales,
+            biases, residual, C, m, n, k, unary_op, workspace_ptr, workspace_bytes, stream);
+    }
+    else
+    {
+        throw std::runtime_error("[FT Error][Unsupported binary op for residual block] " + binary_op);
+    }
 }
 
 template <typename T, typename WeightType, typename Arch>
-void dispatch_gemm_residual(CutlassGemmConfig config, const T *A,
-                            const WeightType *B, const T *weight_scales,
-                            const T *biases, const T *residual, T *C, int m,
-                            int n, int k, const std::string &activation,
-                            const std::string &binary_op,
-                            const std::string &unary_op, char *workspace_ptr,
-                            const size_t workspace_bytes, cudaStream_t stream) {
-  if (activation == "identity") {
-    dispatch_gemm_residual<T, WeightType, Arch,
-                           cutlass::epilogue::thread::Identity>(
-        config, A, B, weight_scales, biases, residual, C, m, n, k, binary_op,
-        unary_op, workspace_ptr, workspace_bytes, stream);
-  } else if ("silu") {
-    dispatch_gemm_residual<T, WeightType, Arch,
-                           cutlass::epilogue::thread::SiLu>(
-        config, A, B, weight_scales, biases, residual, C, m, n, k, binary_op,
-        unary_op, workspace_ptr, workspace_bytes, stream);
-  } else if ("relu") {
-    dispatch_gemm_residual<T, WeightType, Arch,
-                           cutlass::epilogue::thread::ReLu>(
-        config, A, B, weight_scales, biases, residual, C, m, n, k, binary_op,
-        unary_op, workspace_ptr, workspace_bytes, stream);
-  } else if ("gelu") {
-    dispatch_gemm_residual<T, WeightType, Arch,
-                           cutlass::epilogue::thread::GELU>(
-        config, A, B, weight_scales, biases, residual, C, m, n, k, binary_op,
-        unary_op, workspace_ptr, workspace_bytes, stream);
-  } else {
-    throw std::runtime_error(
-        "[FT Error][Unsupported activation before residual binary op] " +
-        activation);
-  }
+void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const WeightType* B, const T* weight_scales,
+    const T* biases, const T* residual, T* C, int m, int n, int k, const std::string& activation,
+    const std::string& binary_op, const std::string& unary_op, char* workspace_ptr, const size_t workspace_bytes,
+    cudaStream_t stream)
+{
+    if (activation == "identity")
+    {
+        dispatch_gemm_residual<T, WeightType, Arch, cutlass::epilogue::thread::Identity>(config, A, B, weight_scales,
+            biases, residual, C, m, n, k, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+    }
+    else if ("silu")
+    {
+        dispatch_gemm_residual<T, WeightType, Arch, cutlass::epilogue::thread::SiLu>(config, A, B, weight_scales,
+            biases, residual, C, m, n, k, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+    }
+    else if ("relu")
+    {
+        dispatch_gemm_residual<T, WeightType, Arch, cutlass::epilogue::thread::ReLu>(config, A, B, weight_scales,
+            biases, residual, C, m, n, k, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+    }
+    else if ("gelu")
+    {
+        dispatch_gemm_residual<T, WeightType, Arch, cutlass::epilogue::thread::GELU>(config, A, B, weight_scales,
+            biases, residual, C, m, n, k, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+    }
+    else
+    {
+        throw std::runtime_error("[FT Error][Unsupported activation before residual binary op] " + activation);
+    }
 }
 
 template <typename T, typename WeightType>
-void CutlassFpAIntBGemmRunner<T, WeightType>::gemm_bias_act_residual(
-    const T *A, const WeightType *B, const T *weight_scales, const T *biases,
-    const T *residual, T *C, int m, int n, int k, const std::string &activation,
-    const std::string &binary_op, const std::string &unary_op,
-    char *workspace_ptr, const size_t workspace_bytes, cudaStream_t stream) {
+void CutlassFpAIntBGemmRunner<T, WeightType>::gemm_bias_act_residual(const T* A, const WeightType* B,
+    const T* weight_scales, const T* biases, const T* residual, T* C, int m, int n, int k,
+    const std::string& activation, const std::string& binary_op, const std::string& unary_op, char* workspace_ptr,
+    const size_t workspace_bytes, cudaStream_t stream)
+{
 
-  std::vector<CutlassGemmConfig> candidate_configs =
-      get_candidate_configs(sm_, true, false);
-  std::vector<int> occupancies(candidate_configs.size());
+    std::vector<CutlassGemmConfig> candidate_configs = get_candidate_configs(sm_, true, false);
+    std::vector<int> occupancies(candidate_configs.size());
 
-  for (size_t ii = 0; ii < candidate_configs.size(); ++ii) {
-    dispatch_to_arch<EpilogueOpNoBias>(
-        A, B, weight_scales, biases, C, m, n, k, 0, candidate_configs[ii],
-        workspace_ptr, workspace_bytes, stream, &occupancies[ii]);
-  }
+    for (size_t ii = 0; ii < candidate_configs.size(); ++ii)
+    {
+        dispatch_to_arch<EpilogueOpNoBias>(A, B, weight_scales, biases, C, m, n, k, 0, candidate_configs[ii],
+            workspace_ptr, workspace_bytes, stream, &occupancies[ii]);
+    }
 
-  CutlassGemmConfig chosen_config = estimate_best_config_from_occupancies(
-      candidate_configs, occupancies, m, n, k, 1, split_k_limit,
-      workspace_bytes, multi_processor_count_, true);
+    CutlassGemmConfig chosen_config = estimate_best_config_from_occupancies(
+        candidate_configs, occupancies, m, n, k, 1, split_k_limit, workspace_bytes, multi_processor_count_, true);
 
-  if (sm_ >= 80 && sm_ < 90) {
-    dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm80>(
-        chosen_config, A, B, weight_scales, biases, residual, C, m, n, k,
-        activation, binary_op, unary_op, workspace_ptr, workspace_bytes,
-        stream);
-  } else if (sm_ >= 75 && sm_ < 80) {
-    dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm75>(
-        chosen_config, A, B, weight_scales, biases, residual, C, m, n, k,
-        activation, binary_op, unary_op, workspace_ptr, workspace_bytes,
-        stream);
-  } else if (sm_ == 70) {
-    dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm70>(
-        chosen_config, A, B, weight_scales, biases, residual, C, m, n, k,
-        activation, binary_op, unary_op, workspace_ptr, workspace_bytes,
-        stream);
-  } else {
-    throw std::runtime_error("[FT Error][Unsupported SM] " + sm_);
-  }
+    if (sm_ >= 80 && sm_ < 90)
+    {
+        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm80>(chosen_config, A, B, weight_scales, biases, residual,
+            C, m, n, k, activation, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+    }
+    else if (sm_ >= 75 && sm_ < 80)
+    {
+        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm75>(chosen_config, A, B, weight_scales, biases, residual,
+            C, m, n, k, activation, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+    }
+    else if (sm_ == 70)
+    {
+        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm70>(chosen_config, A, B, weight_scales, biases, residual,
+            C, m, n, k, activation, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+    }
+    else
+    {
+        throw std::runtime_error("[FT Error][Unsupported SM] " + sm_);
+    }
 }
 
-template<typename T, typename WeightType>
+template <typename T, typename WeightType>
 int CutlassFpAIntBGemmRunner<T, WeightType>::getWorkspaceSize(const int m, const int n, const int k)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
@@ -858,4 +663,4 @@ int CutlassFpAIntBGemmRunner<T, WeightType>::getWorkspaceSize(const int m, const
     return max_grid_m * max_grid_n * split_k_limit * 4;
 }
 
-}  // namespace fastertransformer
+} // namespace fastertransformer

--- a/utils/activation_types.h
+++ b/utils/activation_types.h
@@ -18,9 +18,11 @@
 
 #include "cuda_utils.h"
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
-enum class ActivationType {
+enum class ActivationType
+{
     Gelu,
     Relu,
     Silu,
@@ -34,7 +36,7 @@ enum class ActivationType {
 inline bool isGatedActivation(ActivationType activaiton_type)
 {
     return activaiton_type == ActivationType::GeGLU || activaiton_type == ActivationType::ReGLU
-           || activaiton_type == ActivationType::SiGLU;
+        || activaiton_type == ActivationType::SiGLU;
 }
 
-}  // namespace fastertransformer
+} // namespace fastertransformer

--- a/utils/cuda_utils.h
+++ b/utils/cuda_utils.h
@@ -24,14 +24,16 @@
 #include <string>
 #include <vector>
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 /* **************************** debug tools ********************************* */
-template<typename T>
+template <typename T>
 void check(T result, char const* const func, const char* const file, int const line)
 {
-    if (result) {
-        throw std::runtime_error(std::string("[FT][ERROR] CUDA runtime error: ") + ("<unknown>") + " "
-                                 + file + ":" + std::to_string(line) + " \n");
+    if (result)
+    {
+        throw std::runtime_error(std::string("[FT][ERROR] CUDA runtime error: ") + ("<unknown>") + " " + file + ":"
+            + std::to_string(line) + " \n");
     }
 }
 
@@ -39,22 +41,25 @@ void check(T result, char const* const func, const char* const file, int const l
 
 [[noreturn]] inline void throwRuntimeError(const char* const file, int const line, std::string const& info = "")
 {
-    throw std::runtime_error(std::string("[FT][ERROR] ") + info + " Assertion fail: " + file + ":"
-                             + std::to_string(line) + " \n");
+    throw std::runtime_error(
+        std::string("[FT][ERROR] ") + info + " Assertion fail: " + file + ":" + std::to_string(line) + " \n");
 }
 
 inline void myAssert(bool result, const char* const file, int const line, std::string const& info = "")
 {
-    if (!result) {
+    if (!result)
+    {
         throwRuntimeError(file, line, info);
     }
 }
 
 #define FT_CHECK(val) myAssert(val, __FILE__, __LINE__)
 #define FT_CHECK_WITH_INFO(val, info)                                                                                  \
-    do {                                                                                                               \
+    do                                                                                                                 \
+    {                                                                                                                  \
         bool is_valid_val = (val);                                                                                     \
-        if (!is_valid_val) {                                                                                           \
+        if (!is_valid_val)                                                                                             \
+        {                                                                                                              \
             fastertransformer::myAssert(is_valid_val, __FILE__, __LINE__, (info));                                     \
         }                                                                                                              \
     } while (0)
@@ -73,4 +78,4 @@ inline int getSMVersion()
 
 cudaError_t getSetDevice(int i_device, int* o_device = NULL);
 /* ************************** end of common utils ************************** */
-}  // namespace fastertransformer
+} // namespace fastertransformer

--- a/utils/logger.h
+++ b/utils/logger.h
@@ -22,17 +22,20 @@
 
 #include "string_utils.h"
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
-class Logger {
+class Logger
+{
 
 public:
-    enum Level {
-        TRACE   = 0,
-        DEBUG   = 10,
-        INFO    = 20,
+    enum Level
+    {
+        TRACE = 0,
+        DEBUG = 10,
+        INFO = 20,
         WARNING = 30,
-        ERROR   = 40
+        ERROR = 40
     };
 
     static Logger& getLogger()
@@ -40,26 +43,29 @@ public:
         thread_local Logger instance;
         return instance;
     }
-    Logger(Logger const&)         = delete;
+
+    Logger(Logger const&) = delete;
     void operator=(Logger const&) = delete;
 
-    template<typename... Args>
+    template <typename... Args>
     void log(const Level level, const std::string format, const Args&... args)
     {
-        if (level_ <= level) {
-            std::string fmt    = getPrefix(level) + format + "\n";
-            FILE*       out    = level_ < WARNING ? stdout : stderr;
+        if (level_ <= level)
+        {
+            std::string fmt = getPrefix(level) + format + "\n";
+            FILE* out = level_ < WARNING ? stdout : stderr;
             std::string logstr = fmtstr(fmt, args...);
             fprintf(out, "%s", logstr.c_str());
         }
     }
 
-    template<typename... Args>
+    template <typename... Args>
     void log(const Level level, const int rank, const std::string format, const Args&... args)
     {
-        if (level_ <= level) {
-            std::string fmt    = getPrefix(level, rank) + format + "\n";
-            FILE*       out    = level_ < WARNING ? stdout : stderr;
+        if (level_ <= level)
+        {
+            std::string fmt = getPrefix(level, rank) + format + "\n";
+            FILE* out = level_ < WARNING ? stdout : stderr;
             std::string logstr = fmtstr(fmt, args...);
             fprintf(out, "%s", logstr.c_str());
         }
@@ -77,9 +83,9 @@ public:
     }
 
 private:
-    const std::string                              PREFIX      = "[FT]";
-    const std::map<const Level, const std::string> level_name_ = {
-        {TRACE, "TRACE"}, {DEBUG, "DEBUG"}, {INFO, "INFO"}, {WARNING, "WARNING"}, {ERROR, "ERROR"}};
+    const std::string PREFIX = "[FT]";
+    const std::map<const Level, const std::string> level_name_
+        = {{TRACE, "TRACE"}, {DEBUG, "DEBUG"}, {INFO, "INFO"}, {WARNING, "WARNING"}, {ERROR, "ERROR"}};
 
 #ifndef NDEBUG
     const Level DEFAULT_LOG_LEVEL = DEBUG;
@@ -107,8 +113,10 @@ private:
 };
 
 #define FT_LOG(level, ...)                                                                                             \
-    do {                                                                                                               \
-        if (fastertransformer::Logger::getLogger().getLevel() <= level) {                                              \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        if (fastertransformer::Logger::getLogger().getLevel() <= level)                                                \
+        {                                                                                                              \
             fastertransformer::Logger::getLogger().log(level, __VA_ARGS__);                                            \
         }                                                                                                              \
     } while (0)
@@ -118,4 +126,4 @@ private:
 #define FT_LOG_INFO(...) FT_LOG(fastertransformer::Logger::INFO, __VA_ARGS__)
 #define FT_LOG_WARNING(...) FT_LOG(fastertransformer::Logger::WARNING, __VA_ARGS__)
 #define FT_LOG_ERROR(...) FT_LOG(fastertransformer::Logger::ERROR, __VA_ARGS__)
-}  // namespace fastertransformer
+} // namespace fastertransformer

--- a/utils/string_utils.h
+++ b/utils/string_utils.h
@@ -16,39 +16,41 @@
 
 #pragma once
 
-#include <memory>   // std::make_unique
-#include <sstream>  // std::stringstream
+#include <memory>  // std::make_unique
+#include <sstream> // std::stringstream
 #include <string>
 #include <vector>
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
-template<typename... Args>
+template <typename... Args>
 inline std::string fmtstr(const std::string& format, Args... args)
 {
     // This function came from a code snippet in stackoverflow under cc-by-1.0
     //   https://stackoverflow.com/questions/2342162/stdstring-formatting-like-sprintf
 
     // Disable format-security warning in this function.
-#if defined(_MSC_VER)  // for visual studio
+#if defined(_MSC_VER) // for visual studio
 #pragma warning(push)
 #pragma warning(warning(disable : 4996))
-#elif defined(__GNUC__) || defined(__clang__)  // for gcc or clang
+#elif defined(__GNUC__) || defined(__clang__) // for gcc or clang
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-security"
 #endif
-    int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) + 1;  // Extra space for '\0'
-    if (size_s <= 0) {
+    int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) + 1; // Extra space for '\0'
+    if (size_s <= 0)
+    {
         throw std::runtime_error("Error during formatting.");
     }
     auto size = static_cast<size_t>(size_s);
-    auto buf  = std::make_unique<char[]>(size);
+    auto buf = std::make_unique<char[]>(size);
     std::snprintf(buf.get(), size, format.c_str(), args...);
 #if defined(_MSC_VER)
 #pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
-    return std::string(buf.get(), buf.get() + size - 1);  // We don't want the '\0' inside
+    return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
 }
-}  // namespace fastertransformer
+} // namespace fastertransformer


### PR DESCRIPTION
This is 1/3 PR of integrating tensorrt-llm v0.5 fpA_intB_gemm kernels.

This PR added clang format config from upstream and apply the formatter to the existing code to reduce diff in the future when integrating upstream changes.