### PR TITLE
Add fine grained quantization kernel

### DIFF
--- a/cutlass_kernels/cutlass_heuristic.cc
+++ b/cutlass_kernels/cutlass_heuristic.cc
@@ -103,12 +103,12 @@ std::vector<CutlassTileConfig> get_candidate_tiles(const bool is_weight_only, co
     return simt_configs_only ? simt_configs : allowed_configs;
 }
 
-std::vector<CutlassGemmConfig> get_candidate_configs(int sm, const bool is_weight_only, const bool simt_configs_only)
+std::vector<CutlassGemmConfig> get_candidate_configs(int sm, const bool is_weight_only, cutlass::WeightOnlyQuantOp quant_op, const bool simt_configs_only)
 {
     std::vector<CutlassTileConfig> tiles = get_candidate_tiles(is_weight_only, simt_configs_only);
 
     std::vector<CutlassGemmConfig> candidate_configs;
-    const int min_stages = 2;
+    const int min_stages = isFinegrained(quant_op) ? 3 : 2;
     const int max_stages = sm >= 80 ? 4 : 2;
 
     for (const auto& tile_config : tiles)

--- a/cutlass_kernels/cutlass_heuristic.h
+++ b/cutlass_kernels/cutlass_heuristic.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "cutlass_extensions/gemm_configs.h"
+#include "cutlass_extensions/weight_only_quant_op.h"
 #include <cstddef>
 #include <cstdint>
 #include <vector>
@@ -26,7 +27,8 @@ namespace fastertransformer
 
 using tensorrt_llm::cutlass_extensions::CutlassGemmConfig;
 
-std::vector<CutlassGemmConfig> get_candidate_configs(int sm, const bool is_weight_only, const bool simt_configs_only);
+std::vector<CutlassGemmConfig> get_candidate_configs(
+    int sm, const bool is_weight_only, cutlass::WeightOnlyQuantOp quant_op, bool simt_configs_only);
 
 CutlassGemmConfig estimate_best_config_from_occupancies(const std::vector<CutlassGemmConfig>& candidate_configs,
     const std::vector<int>& occupancies, const int64_t m, const int64_t n, const int64_t k, const int64_t num_experts,

--- a/cutlass_kernels/fpA_intB_gemm.cu
+++ b/cutlass_kernels/fpA_intB_gemm.cu
@@ -1,109 +1,96 @@
 #include "fpA_intB_gemm.h"
 #include "fpA_intB_gemm/fpA_intB_gemm_template.h"
 
-namespace fastertransformer {
+namespace fastertransformer
+{
 
-ActivationType get_activation(const std::string& activation_name) {
-  if (activation_name == "identity") return ActivationType::Identity;
-  if (activation_name == "relu") return ActivationType::Relu;
-  if (activation_name == "silu") return ActivationType::Silu;
-  if (activation_name == "gelu") return ActivationType::Gelu;
-  // todo: more
-  return ActivationType::InvalidType;
+ActivationType get_activation(const std::string& activation_name)
+{
+    if (activation_name == "identity")
+        return ActivationType::Identity;
+    if (activation_name == "relu")
+        return ActivationType::Relu;
+    if (activation_name == "silu")
+        return ActivationType::Silu;
+    if (activation_name == "gelu")
+        return ActivationType::Gelu;
+    // todo: more
+    return ActivationType::InvalidType;
 }
 
 template <typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
-void gemm_fp16_int_bias_act(const half*  A,
-            		    const WeightType* B,
-	        	    const half* weight_scales,
-		            const half* bias,
-               		    half* C,
-               		    std::optional<std::string> activation,
-			    int m, int n, int k, int group_size, int bias_stride, char* workspace_ptr,
-	        	    size_t workspace_bytes, cudaStream_t stream) {
-  CutlassFpAIntBGemmRunner<half, WeightType, QuantOp> runner;
+void gemm_fp16_int_bias_act(const half* A, const WeightType* B, const half* weight_scales, const half* bias, half* C,
+    std::optional<std::string> activation, int m, int n, int k, int group_size, int bias_stride, char* workspace_ptr,
+    size_t workspace_bytes, cudaStream_t stream)
+{
+    CutlassFpAIntBGemmRunner<half, WeightType, QuantOp> runner;
 
-  if (!activation && bias == nullptr) {
-    runner.gemm(A, B, weight_scales,
-		C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
-  } else if (!activation) {
-    runner.gemm_bias_act(A, B, weight_scales, bias,
-			 C, m, n, k, group_size, bias_stride, ActivationType::Identity, workspace_ptr, workspace_bytes, stream);
-  } else {
-    runner.gemm_bias_act(A, B, weight_scales, bias,
-			 C, m, n, k, group_size, bias_stride, get_activation(*activation), workspace_ptr, workspace_bytes, stream);
-  }
+    if (!activation && bias == nullptr)
+    {
+        runner.gemm(A, B, weight_scales, C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
+    }
+    else if (!activation)
+    {
+        runner.gemm_bias_act(A, B, weight_scales, bias, C, m, n, k, group_size, bias_stride, ActivationType::Identity,
+            workspace_ptr, workspace_bytes, stream);
+    }
+    else
+    {
+        runner.gemm_bias_act(A, B, weight_scales, bias, C, m, n, k, group_size, bias_stride,
+            get_activation(*activation), workspace_ptr, workspace_bytes, stream);
+    }
 }
 
 template <typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
-void gemm_fp16_int_bias_act_residual(
-    const half *A, const WeightType *B, const half *weight_scales,
-    const half *bias, const half *residual, half *C, const std::string& activation, const std::string& binary_op,
-    const std::string& unary_op, int m, int n,
-    int k, int group_size, char *workspace_ptr, size_t workspace_bytes, cudaStream_t stream) {
-  CutlassFpAIntBGemmRunner<half, WeightType, QuantOp> runner;
+void gemm_fp16_int_bias_act_residual(const half* A, const WeightType* B, const half* weight_scales, const half* bias,
+    const half* residual, half* C, const std::string& activation, const std::string& binary_op,
+    const std::string& unary_op, int m, int n, int k, int group_size, char* workspace_ptr, size_t workspace_bytes,
+    cudaStream_t stream)
+{
+    CutlassFpAIntBGemmRunner<half, WeightType, QuantOp> runner;
 
-  runner.gemm_bias_act_residual(A, B, weight_scales, bias, residual,
-				C, m, n, k, group_size, activation, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
-
+    runner.gemm_bias_act_residual(A, B, weight_scales, bias, residual, C, m, n, k, group_size, activation, binary_op,
+        unary_op, workspace_ptr, workspace_bytes, stream);
 }
 
-template
-void gemm_fp16_int_bias_act<uint4b_t, cutlass::WeightOnlyQuantOp::PER_COLUMN_SCALE_ONLY>(
-              const half *A, const uint4b_t *B,
-				      const half *weight_scales, const half *bias,
-				      half *C, std::optional<std::string> activation, int m,
-				      int n, int k, int group_size, int bias_stride, char *workspace_ptr,
-				      size_t workspace_bytes, cudaStream_t stream);
+template void gemm_fp16_int_bias_act<uint4b_t, cutlass::WeightOnlyQuantOp::PER_COLUMN_SCALE_ONLY>(const half* A,
+    const uint4b_t* B, const half* weight_scales, const half* bias, half* C, std::optional<std::string> activation,
+    int m, int n, int k, int group_size, int bias_stride, char* workspace_ptr, size_t workspace_bytes,
+    cudaStream_t stream);
 
-template
-void gemm_fp16_int_bias_act_residual<uint4b_t, cutlass::WeightOnlyQuantOp::PER_COLUMN_SCALE_ONLY>(
-    const half *A, const uint4b_t *B, const half *weight_scales,
-    const half *bias, const half *residual, half *C, const std::string& activation, const std::string& binary_op,
-    const std::string& unary_op, int m, int n, int k, int group_size, char *workspace_ptr, size_t workspace_bytes, cudaStream_t stream);
+template void gemm_fp16_int_bias_act_residual<uint4b_t, cutlass::WeightOnlyQuantOp::PER_COLUMN_SCALE_ONLY>(
+    const half* A, const uint4b_t* B, const half* weight_scales, const half* bias, const half* residual, half* C,
+    const std::string& activation, const std::string& binary_op, const std::string& unary_op, int m, int n, int k,
+    int group_size, char* workspace_ptr, size_t workspace_bytes, cudaStream_t stream);
 
-template
-void gemm_fp16_int_bias_act<uint8_t, cutlass::WeightOnlyQuantOp::PER_COLUMN_SCALE_ONLY>(
-             const half *A, const uint8_t *B,
-				     const half *weight_scales, const half *bias,
-				     half *C, std::optional<std::string> activation, int m,
-				     int n, int k,int group_size, int bias_stride, char *workspace_ptr,
-				     size_t workspace_bytes, cudaStream_t stream);
+template void gemm_fp16_int_bias_act<uint8_t, cutlass::WeightOnlyQuantOp::PER_COLUMN_SCALE_ONLY>(const half* A,
+    const uint8_t* B, const half* weight_scales, const half* bias, half* C, std::optional<std::string> activation,
+    int m, int n, int k, int group_size, int bias_stride, char* workspace_ptr, size_t workspace_bytes,
+    cudaStream_t stream);
 
-template
-void gemm_fp16_int_bias_act_residual<uint8_t, cutlass::WeightOnlyQuantOp::PER_COLUMN_SCALE_ONLY>(
-    const half *A, const uint8_t *B, const half *weight_scales,
-    const half *bias, const half *residual, half *C, const std::string& activation, const std::string& binary_op,
-    const std::string& unary_op, int m, int n, int k, int group_size, char *workspace_ptr, size_t workspace_bytes, cudaStream_t stream);
+template void gemm_fp16_int_bias_act_residual<uint8_t, cutlass::WeightOnlyQuantOp::PER_COLUMN_SCALE_ONLY>(const half* A,
+    const uint8_t* B, const half* weight_scales, const half* bias, const half* residual, half* C,
+    const std::string& activation, const std::string& binary_op, const std::string& unary_op, int m, int n, int k,
+    int group_size, char* workspace_ptr, size_t workspace_bytes, cudaStream_t stream);
 
+template void gemm_fp16_int_bias_act<uint4b_t, cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(const half* A,
+    const uint4b_t* B, const half* weight_scales, const half* bias, half* C, std::optional<std::string> activation,
+    int m, int n, int k, int group_size, int bias_stride, char* workspace_ptr, size_t workspace_bytes,
+    cudaStream_t stream);
 
+template void gemm_fp16_int_bias_act_residual<uint4b_t, cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(
+    const half* A, const uint4b_t* B, const half* weight_scales, const half* bias, const half* residual, half* C,
+    const std::string& activation, const std::string& binary_op, const std::string& unary_op, int m, int n, int k,
+    int group_size, char* workspace_ptr, size_t workspace_bytes, cudaStream_t stream);
 
-    template
-void gemm_fp16_int_bias_act<uint4b_t, cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(
-              const half *A, const uint4b_t *B,
-				      const half *weight_scales, const half *bias,
-				      half *C, std::optional<std::string> activation, int m,
-				      int n, int k, int group_size, int bias_stride, char *workspace_ptr,
-				      size_t workspace_bytes, cudaStream_t stream);
+template void gemm_fp16_int_bias_act<uint8_t, cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(const half* A,
+    const uint8_t* B, const half* weight_scales, const half* bias, half* C, std::optional<std::string> activation,
+    int m, int n, int k, int group_size, int bias_stride, char* workspace_ptr, size_t workspace_bytes,
+    cudaStream_t stream);
 
-template
-void gemm_fp16_int_bias_act_residual<uint4b_t, cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(
-    const half *A, const uint4b_t *B, const half *weight_scales,
-    const half *bias, const half *residual, half *C, const std::string& activation, const std::string& binary_op,
-    const std::string& unary_op, int m, int n, int k, int group_size, char *workspace_ptr, size_t workspace_bytes, cudaStream_t stream);
-
-template
-void gemm_fp16_int_bias_act<uint8_t, cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(
-             const half *A, const uint8_t *B,
-				     const half *weight_scales, const half *bias,
-				     half *C, std::optional<std::string> activation, int m,
-				     int n, int k,int group_size, int bias_stride, char *workspace_ptr,
-				     size_t workspace_bytes, cudaStream_t stream);
-
-template
-void gemm_fp16_int_bias_act_residual<uint8_t, cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(
-    const half *A, const uint8_t *B, const half *weight_scales,
-    const half *bias, const half *residual, half *C, const std::string& activation, const std::string& binary_op,
-    const std::string& unary_op, int m, int n, int k, int group_size, char *workspace_ptr, size_t workspace_bytes, cudaStream_t stream);
+template void gemm_fp16_int_bias_act_residual<uint8_t, cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY>(
+    const half* A, const uint8_t* B, const half* weight_scales, const half* bias, const half* residual, half* C,
+    const std::string& activation, const std::string& binary_op, const std::string& unary_op, int m, int n, int k,
+    int group_size, char* workspace_ptr, size_t workspace_bytes, cudaStream_t stream);
 
 } // namespace fastertransformer

--- a/cutlass_kernels/fpA_intB_gemm.h
+++ b/cutlass_kernels/fpA_intB_gemm.h
@@ -8,6 +8,7 @@
 #include "cutlass/numeric_types.h"
 #include "cutlass/integer_subbyte.h"
 // clang-format on
+#include "cutlass_extensions/include/cutlass_extensions/weight_only_quant_op.h"
 #include <cuda_runtime.h>
 
 namespace fastertransformer
@@ -21,14 +22,16 @@ void preprocess_weights(int8_t* preprocessed_quantized_weight, const int8_t* row
 
 // TODO: Support more general bias shape
 
-template <typename WeightType>
+template <typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
 void gemm_fp16_int_bias_act(const half* A, const WeightType* B, const half* weight_scales, const half* bias, half* C,
-    std::optional<std::string> activation, int m, int n, int k, int bias_stride, char* workspace_ptr,
+    std::optional<std::string> activation, int m, int n, int k, int group_size, int bias_stride, char* workspace_ptr,
     size_t workspace_bytes, cudaStream_t stream);
 
-template <typename WeightType>
+template <typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
 void gemm_fp16_int_bias_act_residual(const half* A, const WeightType* B, const half* weight_scales, const half* bias,
     const half* residual, half* C, const std::string& activation, const std::string& binary_op,
-    const std::string& unary_op, int m, int n, int k, char* workspace_ptr, size_t workspace_bytes, cudaStream_t stream);
+    const std::string& unary_op, int m, int n, int k, int group_size, char* workspace_ptr, size_t workspace_bytes,
+    cudaStream_t stream);
+
 
 } // namespace fastertransformer

--- a/cutlass_kernels/fpA_intB_gemm.h
+++ b/cutlass_kernels/fpA_intB_gemm.h
@@ -20,8 +20,6 @@ using uint4b_t = cutlass::uint4b_t;
 void preprocess_weights(int8_t* preprocessed_quantized_weight, const int8_t* row_major_quantized_weight, size_t rows,
     size_t cols, bool is_int4, int arch);
 
-// TODO: Support more general bias shape
-
 template <typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
 void gemm_fp16_int_bias_act(const half* A, const WeightType* B, const half* weight_scales, const half* bias, half* C,
     std::optional<std::string> activation, int m, int n, int k, int group_size, int bias_stride, char* workspace_ptr,
@@ -32,6 +30,5 @@ void gemm_fp16_int_bias_act_residual(const half* A, const WeightType* B, const h
     const half* residual, half* C, const std::string& activation, const std::string& binary_op,
     const std::string& unary_op, int m, int n, int k, int group_size, char* workspace_ptr, size_t workspace_bytes,
     cudaStream_t stream);
-
 
 } // namespace fastertransformer

--- a/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm.h
+++ b/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include "cutlass_extensions/include/cutlass_extensions/gemm_configs.h"
+#include "cutlass_extensions/include/cutlass_extensions/weight_only_quant_op.h"
 #include "utils/activation_types.h"
 #include <cuda_runtime_api.h>
 
@@ -35,23 +36,24 @@ namespace fastertransformer
   modifications to mix_gemm_B_layout.h.
 */
 
-template <typename T, typename WeightType>
+template <typename T, typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
 class CutlassFpAIntBGemmRunner
 {
 public:
     CutlassFpAIntBGemmRunner();
     ~CutlassFpAIntBGemmRunner();
 
-    void gemm(const T* A, const WeightType* B, const T* weight_scales, T* C, int m, int n, int k, char* workspace_ptr,
-        const size_t workspace_bytes, cudaStream_t stream);
+    void gemm(const T* A, const WeightType* B, const T* weight_scales, T* C, int m, int n, int k, int group_size,
+        char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream);
 
     void gemm_bias_act(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
-        int k, int bias_stride, ActivationType activation_type, char* workspace_ptr, const size_t workspace_bytes,
-        cudaStream_t stream);
+        int k, int group_size, int bias_stride, ActivationType activation_type, char* workspace_ptr,
+        const size_t workspace_bytes, cudaStream_t stream);
 
     void gemm_bias_act_residual(const T* A, const WeightType* B, const T* weight_scales, const T* biases,
-        const T* residual, T* C, int m, int n, int k, const std::string& activation, const std::string& binary_op,
-        const std::string& unary_op, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream);
+        const T* residual, T* C, int m, int n, int k, int group_size, const std::string& activation,
+        const std::string& binary_op, const std::string& unary_op, char* workspace_ptr, const size_t workspace_bytes,
+        cudaStream_t stream);
 
     // Returns desired workspace size in bytes.
     int getWorkspaceSize(const int m, const int n, const int k);
@@ -59,15 +61,17 @@ public:
 private:
     template <typename EpilogueTag>
     void dispatch_to_arch(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
-        int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace_ptr, const size_t workspace_bytes,
-        cudaStream_t stream, int* occupancy = nullptr);
+        int k, int group_size, int bias_stride, CutlassGemmConfig gemm_config, char* workspace_ptr,
+        const size_t workspace_bytes, cudaStream_t stream, int* occupancy = nullptr);
 
     template <typename EpilogueTag>
     void run_gemm(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n, int k,
-        int bias_stride, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream);
+        int group_size, int bias_stride, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream);
 
 private:
-    static constexpr int split_k_limit = 7;
+    static constexpr int SPLIT_K_LIMIT = 7;
+    static constexpr int MIN_M_TILE = 32;
+    static constexpr int MIN_N_TILE = 128;
 
     int sm_;
     int multi_processor_count_;

--- a/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm_template.h
+++ b/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm_template.h
@@ -41,11 +41,11 @@ namespace fastertransformer
 
 using namespace tensorrt_llm::cutlass_extensions;
 
-template <typename T, typename WeightType, typename arch, typename EpilogueTag, typename ThreadblockShape,
-    typename WarpShape, int Stages>
+template <typename T, typename WeightType, typename arch, cutlass::WeightOnlyQuantOp QuantOp, typename EpilogueTag,
+    typename ThreadblockShape, typename WarpShape, int Stages>
 void generic_mixed_gemm_kernelLauncher(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C,
-    int m, int n, int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
-    cudaStream_t stream, int* occupancy = nullptr)
+    int m, int n, int k, int group_size, int bias_stride, CutlassGemmConfig gemm_config, char* workspace,
+    size_t workspace_bytes, cudaStream_t stream, int* occupancy = nullptr)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
     static_assert(cutlass::platform::is_same<T, half>::value || cutlass::platform::is_same<T, float>::value,
@@ -74,13 +74,16 @@ void generic_mixed_gemm_kernelLauncher(const T* A, const WeightType* B, const T*
     using EpilogueOp =
         typename Epilogue<ElementType, MixedGemmArchTraits::ElementsPerAccessC, ElementAccumulator, EpilogueTag>::Op;
 
+    using Operator = typename MixedGemmArchTraits::Operator;
+    using TaggedOperator = typename cutlass::arch::TagOperator<Operator, QuantOp>::TaggedOperator;
+
     using GemmKernel_ = typename cutlass::gemm::kernel::DefaultGemm<ElementType, cutlass::layout::RowMajor,
         MixedGemmArchTraits::ElementsPerAccessA, CutlassWeightType, typename MixedGemmArchTraits::LayoutB,
         MixedGemmArchTraits::ElementsPerAccessB, ElementType, cutlass::layout::RowMajor, ElementAccumulator,
         cutlass::arch::OpClassTensorOp, arch, ThreadblockShape, WarpShape,
         typename MixedGemmArchTraits::InstructionShape, EpilogueOp,
         typename cutlass::gemm::threadblock::GemmIdentityThreadblockSwizzle<>, Stages, true,
-        typename MixedGemmArchTraits::Operator>::GemmKernel;
+        TaggedOperator>::GemmKernel;
 
     using GemmKernel = cutlass::gemm::kernel::GemmFpAIntB<typename GemmKernel_::Mma, typename GemmKernel_::Epilogue,
         typename GemmKernel_::ThreadblockSwizzle,
@@ -99,13 +102,55 @@ void generic_mixed_gemm_kernelLauncher(const T* A, const WeightType* B, const T*
         ? n
         : k * GemmKernel::kInterleave;
 
-    typename Gemm::Arguments args({m, n, k}, /*group_size=*/k, {reinterpret_cast<ElementType*>(const_cast<T*>(A)), k},
+    if (weight_scales == nullptr)
+    {
+        throw std::runtime_error("Weight scales must always be set to a non-null value.");
+    }
+
+    if constexpr (cutlass::isFinegrained(QuantOp))
+    {
+        if (group_size != 64 && group_size != 128)
+        {
+            throw std::runtime_error("Only group size 64 and 128 supported for fine grained kernels.");
+        }
+
+        // if constexpr (QuantOp == cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_ONLY)
+        // {
+        //     if (weight_zero_points != nullptr)
+        //     {
+        //         throw std::runtime_error("Weight zero pointer must be a nullptr for scale only fine grained");
+        //     }
+        // }
+        // else if constexpr (QuantOp == cutlass::WeightOnlyQuantOp::FINEGRAINED_SCALE_AND_ZEROS)
+        // {
+        //     if (weight_zero_points == nullptr)
+        //     {
+        //         throw std::runtime_error("Weight zero pointer must be valid for scale and bias fine grained");
+        //     }
+        // }
+    }
+    else
+    {
+        if (group_size != k)
+        {
+            throw std::runtime_error("Invalid group size for per column scaling kernels.");
+        }
+
+        // if (weight_zero_points != nullptr)
+        // {
+        //     throw std::runtime_error("Weight zero-points must be null when running per column scaling");
+        // }
+    }
+
+    const int ld_scale_zero = cutlass::isFinegrained(QuantOp) ? n : 0;
+    ElementAccumulator output_op_beta = (biases == nullptr) ? ElementAccumulator(0.f) : ElementAccumulator(1.f);
+    typename Gemm::Arguments args({m, n, k}, group_size, {reinterpret_cast<ElementType*>(const_cast<T*>(A)), k},
         {reinterpret_cast<CutlassWeightType*>(const_cast<WeightType*>(B)), ldb},
-        {reinterpret_cast<ElementType*>(const_cast<T*>(weight_scales)), 0},
+        {reinterpret_cast<ElementType*>(const_cast<T*>(weight_scales)), ld_scale_zero},
         /*weight_zero_points=*/{nullptr, 0},
         // TODO: Support more general bias shape
         {reinterpret_cast<ElementType*>(const_cast<T*>(biases)), bias_stride}, {reinterpret_cast<ElementType*>(C), n},
-        gemm_config.split_k_factor, {ElementAccumulator(1.f), ElementAccumulator(0.f)});
+        gemm_config.split_k_factor, {ElementAccumulator(1.f), output_op_beta});
 
     // This assertion is enabled because because for the column interleaved layout, K MUST be a multiple of
     // threadblockK. The reason for this is that the default pitchlinear iterators are used to handle walking over the
@@ -152,12 +197,14 @@ void generic_mixed_gemm_kernelLauncher(const T* A, const WeightType* B, const T*
     }
 }
 
-template <typename T, typename WeightType, typename arch, typename EpilogueTag, typename ThreadblockShape,
-    typename WarpShape, int Stages, typename Enable = void>
+// TODO(wuwei): do we need filter_and_run?
+
+template <typename T, typename WeightType, typename arch, cutlass::WeightOnlyQuantOp QuantOp, typename EpilogueTag,
+    typename ThreadblockShape, typename WarpShape, int Stages, typename Enable = void>
 struct dispatch_stages
 {
     static void dispatch(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
-        int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
+        int k, int group_size, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
         cudaStream_t stream, int* occupancy = nullptr)
     {
 
@@ -168,62 +215,67 @@ struct dispatch_stages
     }
 };
 
-template <typename T, typename WeightType, typename arch, typename EpilogueTag, typename ThreadblockShape,
-    typename WarpShape>
-struct dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 2>
+template <typename T, typename WeightType, typename arch, cutlass::WeightOnlyQuantOp QuantOp, typename EpilogueTag,
+    typename ThreadblockShape, typename WarpShape>
+struct dispatch_stages<T, WeightType, arch, QuantOp, EpilogueTag, ThreadblockShape, WarpShape, 2,
+    std::enable_if_t<!isFinegrained(QuantOp)>>
 {
     static void dispatch(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
-        int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
+        int k, int group_size, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
         cudaStream_t stream, int* occupancy = nullptr)
     {
 
         FT_LOG_DEBUG(__PRETTY_FUNCTION__);
-        generic_mixed_gemm_kernelLauncher<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 2>(A, B,
-            weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes, stream, occupancy);
-    }
-};
-
-template <typename T, typename WeightType, typename EpilogueTag, typename ThreadblockShape, typename WarpShape,
-    int Stages>
-struct dispatch_stages<T, WeightType, cutlass::arch::Sm80, EpilogueTag, ThreadblockShape, WarpShape, Stages,
-    typename std::enable_if<(Stages > 2)>::type>
-{
-    static void dispatch(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
-        int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
-        cudaStream_t stream, int* occupancy = nullptr)
-    {
-
-        FT_LOG_DEBUG(__PRETTY_FUNCTION__);
-        generic_mixed_gemm_kernelLauncher<T, WeightType, cutlass::arch::Sm80, EpilogueTag, ThreadblockShape, WarpShape,
-            Stages>(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace, workspace_bytes,
+        generic_mixed_gemm_kernelLauncher<T, WeightType, arch, QuantOp, EpilogueTag, ThreadblockShape, WarpShape, 2>(A,
+            B, weight_scales, biases, C, m, n, k, group_size, bias_stride, gemm_config, workspace, workspace_bytes,
             stream, occupancy);
     }
 };
 
-template <typename T, typename WeightType, typename arch, typename EpilogueTag, typename ThreadblockShape,
-    typename WarpShape>
+template <typename T, typename WeightType, cutlass::WeightOnlyQuantOp QuantOp, typename EpilogueTag,
+    typename ThreadblockShape, typename WarpShape, int Stages>
+struct dispatch_stages<T, WeightType, cutlass::arch::Sm80, QuantOp, EpilogueTag, ThreadblockShape, WarpShape, Stages,
+    typename std::enable_if<(Stages > 2)>::type>
+{
+    static void dispatch(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
+        int k, int group_size, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
+        cudaStream_t stream, int* occupancy = nullptr)
+    {
+
+        FT_LOG_DEBUG(__PRETTY_FUNCTION__);
+        generic_mixed_gemm_kernelLauncher<T, WeightType, cutlass::arch::Sm80, QuantOp, EpilogueTag, ThreadblockShape,
+            WarpShape, Stages>(A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride, gemm_config, workspace,
+            workspace_bytes, stream, occupancy);
+    }
+};
+
+template <typename T, typename WeightType, typename arch, cutlass::WeightOnlyQuantOp QuantOp, typename EpilogueTag,
+    typename ThreadblockShape, typename WarpShape>
 void dispatch_gemm_config(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m, int n,
-    int k, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes, cudaStream_t stream,
-    int* occupancy = nullptr)
+    int k, int group_size, int bias_stride, CutlassGemmConfig gemm_config, char* workspace, size_t workspace_bytes,
+    cudaStream_t stream, int* occupancy = nullptr)
 {
 
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
     switch (gemm_config.stages)
     {
     case 2:
-        using DispatcherStages2 = dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 2>;
-        DispatcherStages2::dispatch(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace,
-            workspace_bytes, stream, occupancy);
+        using DispatcherStages2
+            = dispatch_stages<T, WeightType, arch, QuantOp, EpilogueTag, ThreadblockShape, WarpShape, 2>;
+        DispatcherStages2::dispatch(A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride, gemm_config,
+            workspace, workspace_bytes, stream, occupancy);
         break;
     case 3:
-        using DispatcherStages3 = dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 3>;
-        DispatcherStages3::dispatch(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace,
-            workspace_bytes, stream, occupancy);
+        using DispatcherStages3
+            = dispatch_stages<T, WeightType, arch, QuantOp, EpilogueTag, ThreadblockShape, WarpShape, 3>;
+        DispatcherStages3::dispatch(A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride, gemm_config,
+            workspace, workspace_bytes, stream, occupancy);
         break;
     case 4:
-        using DispatcherStages4 = dispatch_stages<T, WeightType, arch, EpilogueTag, ThreadblockShape, WarpShape, 4>;
-        DispatcherStages4::dispatch(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config, workspace,
-            workspace_bytes, stream, occupancy);
+        using DispatcherStages4
+            = dispatch_stages<T, WeightType, arch, QuantOp, EpilogueTag, ThreadblockShape, WarpShape, 4>;
+        DispatcherStages4::dispatch(A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride, gemm_config,
+            workspace, workspace_bytes, stream, occupancy);
         break;
     default:
         std::string err_msg = "dispatch_gemm_config does not support stages " + std::to_string(gemm_config.stages);
@@ -232,10 +284,10 @@ void dispatch_gemm_config(const T* A, const WeightType* B, const T* weight_scale
     }
 }
 
-template <typename T, typename WeightType, typename arch, typename EpilogueTag>
+template <typename T, typename WeightType, typename arch, cutlass::WeightOnlyQuantOp QuantOp, typename EpilogueTag>
 void dispatch_gemm_to_cutlass(const T* A, const WeightType* B, const T* weight_scales, const T* biases, T* C, int m,
-    int n, int k, int bias_stride, char* workspace, size_t workspace_bytes, CutlassGemmConfig gemm_config,
-    cudaStream_t stream, int* occupancy = nullptr)
+    int n, int k, int group_size, int bias_stride, char* workspace, size_t workspace_bytes,
+    CutlassGemmConfig gemm_config, cudaStream_t stream, int* occupancy = nullptr)
 {
 
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
@@ -246,19 +298,19 @@ void dispatch_gemm_to_cutlass(const T* A, const WeightType* B, const T* weight_s
     switch (gemm_config.tile_config)
     {
     case CutlassTileConfig::CtaShape32x128x64_WarpShape32x32x64:
-        dispatch_gemm_config<T, WeightType, arch, EpilogueTag, cutlass::gemm::GemmShape<32, 128, 64>,
-            cutlass::gemm::GemmShape<32, 32, 64>>(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config,
-            workspace, workspace_bytes, stream, occupancy);
+        dispatch_gemm_config<T, WeightType, arch, QuantOp, EpilogueTag, cutlass::gemm::GemmShape<32, 128, 64>,
+            cutlass::gemm::GemmShape<32, 32, 64>>(A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride,
+            gemm_config, workspace, workspace_bytes, stream, occupancy);
         break;
     case CutlassTileConfig::CtaShape64x128x64_WarpShape64x32x64:
-        dispatch_gemm_config<T, WeightType, arch, EpilogueTag, cutlass::gemm::GemmShape<64, 128, 64>,
-            cutlass::gemm::GemmShape<64, 32, 64>>(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config,
-            workspace, workspace_bytes, stream, occupancy);
+        dispatch_gemm_config<T, WeightType, arch, QuantOp, EpilogueTag, cutlass::gemm::GemmShape<64, 128, 64>,
+            cutlass::gemm::GemmShape<64, 32, 64>>(A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride,
+            gemm_config, workspace, workspace_bytes, stream, occupancy);
         break;
     case CutlassTileConfig::CtaShape128x128x64_WarpShape128x32x64:
-        dispatch_gemm_config<T, WeightType, arch, EpilogueTag, cutlass::gemm::GemmShape<128, 128, 64>,
-            cutlass::gemm::GemmShape<128, 32, 64>>(A, B, weight_scales, biases, C, m, n, k, bias_stride, gemm_config,
-            workspace, workspace_bytes, stream, occupancy);
+        dispatch_gemm_config<T, WeightType, arch, QuantOp, EpilogueTag, cutlass::gemm::GemmShape<128, 128, 64>,
+            cutlass::gemm::GemmShape<128, 32, 64>>(A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride,
+            gemm_config, workspace, workspace_bytes, stream, occupancy);
         break;
     case CutlassTileConfig::Undefined:
         throw std::runtime_error("[FT Error][fpA_intB][dispatch_gemm_to_cutlass] gemm config undefined.");
@@ -274,8 +326,8 @@ void dispatch_gemm_to_cutlass(const T* A, const WeightType* B, const T* weight_s
     }
 }
 
-template <typename T, typename WeightType>
-CutlassFpAIntBGemmRunner<T, WeightType>::CutlassFpAIntBGemmRunner()
+template <typename T, typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
+CutlassFpAIntBGemmRunner<T, WeightType, QuantOp>::CutlassFpAIntBGemmRunner()
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
     int device{-1};
@@ -284,33 +336,34 @@ CutlassFpAIntBGemmRunner<T, WeightType>::CutlassFpAIntBGemmRunner()
     check_cuda_error(cudaDeviceGetAttribute(&multi_processor_count_, cudaDevAttrMultiProcessorCount, device));
 }
 
-template <typename T, typename WeightType>
-CutlassFpAIntBGemmRunner<T, WeightType>::~CutlassFpAIntBGemmRunner()
+template <typename T, typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
+CutlassFpAIntBGemmRunner<T, WeightType, QuantOp>::~CutlassFpAIntBGemmRunner()
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
 }
 
-template <typename T, typename WeightType>
+template <typename T, typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
 template <typename EpilogueTag>
-void CutlassFpAIntBGemmRunner<T, WeightType>::dispatch_to_arch<EpilogueTag>(const T* A, const WeightType* B,
-    const T* weight_scales, const T* biases, T* C, int m, int n, int k, int bias_stride, CutlassGemmConfig gemm_config,
-    char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream, int* occupancy)
+void CutlassFpAIntBGemmRunner<T, WeightType, QuantOp>::dispatch_to_arch<EpilogueTag>(const T* A, const WeightType* B,
+    const T* weight_scales, const T* biases, T* C, int m, int n, int k, int group_size, int bias_stride,
+    CutlassGemmConfig gemm_config, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream,
+    int* occupancy)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
     if (sm_ >= 70 && sm_ < 75)
     {
-        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm70, EpilogueTag>(A, B, weight_scales, biases, C, m, n,
-            k, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
+        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm70, QuantOp, EpilogueTag>(A, B, weight_scales, biases,
+            C, m, n, k, group_size, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
     }
     else if (sm_ >= 75 && sm_ < 80)
     {
-        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm75, EpilogueTag>(A, B, weight_scales, biases, C, m, n,
-            k, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
+        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm75, QuantOp, EpilogueTag>(A, B, weight_scales, biases,
+            C, m, n, k, group_size, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
     }
     else if (sm_ >= 80 && sm_ < 90)
     {
-        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm80, EpilogueTag>(A, B, weight_scales, biases, C, m, n,
-            k, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
+        dispatch_gemm_to_cutlass<T, WeightType, cutlass::arch::Sm80, QuantOp, EpilogueTag>(A, B, weight_scales, biases,
+            C, m, n, k, group_size, bias_stride, workspace_ptr, workspace_bytes, gemm_config, stream, occupancy);
     }
     else
     {
@@ -319,35 +372,35 @@ void CutlassFpAIntBGemmRunner<T, WeightType>::dispatch_to_arch<EpilogueTag>(cons
     }
 }
 
-template <typename T, typename WeightType>
+template <typename T, typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
 template <typename EpilogueTag>
-void CutlassFpAIntBGemmRunner<T, WeightType>::run_gemm<EpilogueTag>(const T* A, const WeightType* B,
-    const T* weight_scales, const T* biases, T* C, int m, int n, int k, int bias_stride, char* workspace_ptr,
-    const size_t workspace_bytes, cudaStream_t stream)
+void CutlassFpAIntBGemmRunner<T, WeightType, QuantOp>::run_gemm<EpilogueTag>(const T* A, const WeightType* B,
+    const T* weight_scales, const T* biases, T* C, int m, int n, int k, int group_size, int bias_stride,
+    char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
     static constexpr bool is_weight_only = !std::is_same<T, WeightType>::value;
-    std::vector<CutlassGemmConfig> candidate_configs = get_candidate_configs(sm_, is_weight_only, false);
+    std::vector<CutlassGemmConfig> candidate_configs = get_candidate_configs(sm_, is_weight_only, QuantOp, false);
     std::vector<int> occupancies(candidate_configs.size());
 
     for (size_t ii = 0; ii < candidate_configs.size(); ++ii)
     {
-        dispatch_to_arch<EpilogueTag>(A, B, weight_scales, biases, C, m, n, k, bias_stride, candidate_configs[ii],
-            workspace_ptr, workspace_bytes, stream, &occupancies[ii]);
+        dispatch_to_arch<EpilogueTag>(A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride,
+            candidate_configs[ii], workspace_ptr, workspace_bytes, stream, &occupancies[ii]);
     }
     // Standard GEMM, so 1 "expert". We use the same function for MoE and regular FFN.
     static constexpr int num_experts = 1;
     CutlassGemmConfig chosen_config = estimate_best_config_from_occupancies(candidate_configs, occupancies, m, n, k,
-        num_experts, split_k_limit, workspace_bytes, multi_processor_count_, is_weight_only);
+        num_experts, SPLIT_K_LIMIT, workspace_bytes, multi_processor_count_, is_weight_only);
 
-    dispatch_to_arch<EpilogueTag>(
-        A, B, weight_scales, biases, C, m, n, k, bias_stride, chosen_config, workspace_ptr, workspace_bytes, stream);
+    dispatch_to_arch<EpilogueTag>(A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride, chosen_config,
+        workspace_ptr, workspace_bytes, stream);
 }
 
-template <typename T, typename WeightType>
-void CutlassFpAIntBGemmRunner<T, WeightType>::gemm_bias_act(const T* A, const WeightType* B, const T* weight_scales,
-    const T* biases, T* C, int m, int n, int k, int bias_stride, ActivationType activation_type, char* workspace_ptr,
-    const size_t workspace_bytes, cudaStream_t stream)
+template <typename T, typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
+void CutlassFpAIntBGemmRunner<T, WeightType, QuantOp>::gemm_bias_act(const T* A, const WeightType* B,
+    const T* weight_scales, const T* biases, T* C, int m, int n, int k, int group_size, int bias_stride,
+    ActivationType activation_type, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
 
@@ -355,19 +408,19 @@ void CutlassFpAIntBGemmRunner<T, WeightType>::gemm_bias_act(const T* A, const We
     {
     case ActivationType::Relu:
         run_gemm<EpilogueOpBiasReLU>(
-            A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
+            A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride, workspace_ptr, workspace_bytes, stream);
         break;
     case ActivationType::Gelu:
         run_gemm<EpilogueOpBiasFtGelu>(
-            A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
+            A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride, workspace_ptr, workspace_bytes, stream);
         break;
     case ActivationType::Silu:
         run_gemm<EpilogueOpBiasSilu>(
-            A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
+            A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride, workspace_ptr, workspace_bytes, stream);
         break;
     case ActivationType::Identity:
         run_gemm<EpilogueOpBias>(
-            A, B, weight_scales, biases, C, m, n, k, bias_stride, workspace_ptr, workspace_bytes, stream);
+            A, B, weight_scales, biases, C, m, n, k, group_size, bias_stride, workspace_ptr, workspace_bytes, stream);
         break;
     case ActivationType::InvalidType: FT_CHECK_WITH_INFO(false, "Activation type for fpA_intB must be valid."); break;
     default:
@@ -384,18 +437,19 @@ void CutlassFpAIntBGemmRunner<T, WeightType>::gemm_bias_act(const T* A, const We
     }
 }
 
-template <typename T, typename WeightType>
-void CutlassFpAIntBGemmRunner<T, WeightType>::gemm(const T* A, const WeightType* B, const T* weight_scales, T* C, int m,
-    int n, int k, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream)
+template <typename T, typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
+void CutlassFpAIntBGemmRunner<T, WeightType, QuantOp>::gemm(const T* A, const WeightType* B, const T* weight_scales,
+    T* C, int m, int n, int k, int group_size, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
-    run_gemm<EpilogueOpNoBias>(A, B, weight_scales, nullptr, C, m, n, k, 0, workspace_ptr, workspace_bytes, stream);
+    run_gemm<EpilogueOpNoBias>(
+        A, B, weight_scales, nullptr, C, m, n, k, group_size, 0, workspace_ptr, workspace_bytes, stream);
 }
 
-template <typename T, typename WeightType, typename Arch, typename ThreadblockShape, typename WarpShape,
-    typename EpilogueOp, int stages>
+template <typename T, typename WeightType, typename Arch, cutlass::WeightOnlyQuantOp QuantOp, typename ThreadblockShape,
+    typename WarpShape, typename EpilogueOp, int stages>
 void dispatch_gemm_residual(const T* A, const WeightType* B, const T* weight_scales, const T* biases, const T* residual,
-    T* C, int m, int n, int k, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream)
+    T* C, int m, int n, int k, int group_size, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream)
 {
     using ElementType =
         typename cutlass::platform::conditional<cutlass::platform::is_same<T, half>::value, cutlass::half_t, T>::type;
@@ -414,11 +468,14 @@ void dispatch_gemm_residual(const T* A, const WeightType* B, const T* weight_sca
         cutlass::arch::OpClassTensorOp, Arch, ThreadblockShape, WarpShape, InstructionShape, EpilogueOp, Swizzle,
         stages, typename MixedGemmArchTraits::Operator>::Epilogue;
 
+    using Operator = typename MixedGemmArchTraits::Operator;
+    using TaggedOperator = typename cutlass::arch::TagOperator<Operator, QuantOp>::TaggedOperator;
+
     using GemmKernel_ = typename cutlass::gemm::kernel::DefaultGemm<ElementType, cutlass::layout::RowMajor,
         MixedGemmArchTraits::ElementsPerAccessA, WeightType, typename MixedGemmArchTraits::LayoutB,
         MixedGemmArchTraits::ElementsPerAccessB, ElementType, cutlass::layout::RowMajor, ElementAccumulator,
         cutlass::arch::OpClassTensorOp, Arch, ThreadblockShape, WarpShape, InstructionShape, EpilogueOp, Swizzle,
-        stages, true, typename MixedGemmArchTraits::Operator>::GemmKernel;
+        stages, true, TaggedOperator>::GemmKernel;
 
     using GemmKernel = cutlass::gemm::kernel::GemmFpAIntBWithBroadcast<typename GemmKernel_::Mma, Epilogue,
         typename GemmKernel_::ThreadblockSwizzle, Arch>;
@@ -427,7 +484,6 @@ void dispatch_gemm_residual(const T* A, const WeightType* B, const T* weight_sca
 
     // TODO: Support batch
     const int batch_count = 1;
-    const int group_size = k;
     const auto lda = k;
     const int ldb = cutlass::platform::is_same<cutlass::layout::RowMajor, typename MixedGemmArchTraits::LayoutB>::value
         ? n
@@ -470,71 +526,77 @@ void dispatch_gemm_residual(const T* A, const WeightType* B, const T* weight_sca
     }
 }
 
-template <typename T, typename WeightType, typename Arch, typename EpilogueOp, int stages>
+template <typename T, typename WeightType, typename Arch, cutlass::WeightOnlyQuantOp QuantOp, typename EpilogueOp,
+    int stages>
 void dispatch_gemm_residual(CutlassTileConfig tile_config, const T* A, const WeightType* B, const T* weight_scales,
-    const T* biases, const T* residual, T* C, int m, int n, int k, char* workspace_ptr, const size_t workspace_bytes,
-    cudaStream_t stream)
+    const T* biases, const T* residual, T* C, int m, int n, int k, int group_size, char* workspace_ptr,
+    const size_t workspace_bytes, cudaStream_t stream)
 {
     if (tile_config == CutlassTileConfig::CtaShape32x128x64_WarpShape32x32x64)
     {
-        dispatch_gemm_residual<T, WeightType, Arch, cutlass::gemm::GemmShape<32, 128, 64>,
+        dispatch_gemm_residual<T, WeightType, Arch, QuantOp, cutlass::gemm::GemmShape<32, 128, 64>,
             cutlass::gemm::GemmShape<32, 32, 64>, EpilogueOp, stages>(
-            A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+            A, B, weight_scales, biases, residual, C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
     }
     else if (tile_config == CutlassTileConfig::CtaShape64x128x64_WarpShape64x32x64)
     {
-        dispatch_gemm_residual<T, WeightType, Arch, cutlass::gemm::GemmShape<64, 128, 64>,
+        dispatch_gemm_residual<T, WeightType, Arch, QuantOp, cutlass::gemm::GemmShape<64, 128, 64>,
             cutlass::gemm::GemmShape<64, 32, 64>, EpilogueOp, stages>(
-            A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+            A, B, weight_scales, biases, residual, C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
     }
     else
     { // CutlassTileConfig::CtaShape128x128x64_WarpShape128x32x64:
-        dispatch_gemm_residual<T, WeightType, Arch, cutlass::gemm::GemmShape<128, 128, 64>,
+        dispatch_gemm_residual<T, WeightType, Arch, QuantOp, cutlass::gemm::GemmShape<128, 128, 64>,
             cutlass::gemm::GemmShape<128, 32, 64>, EpilogueOp, stages>(
-            A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+            A, B, weight_scales, biases, residual, C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
     }
 }
 
-template <typename T, typename WeightType, typename Arch, typename EpilogueOp>
+template <typename T, typename WeightType, typename Arch, cutlass::WeightOnlyQuantOp QuantOp, typename EpilogueOp>
 void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const WeightType* B, const T* weight_scales,
-    const T* biases, const T* residual, T* C, int m, int n, int k, char* workspace_ptr, const size_t workspace_bytes,
-    cudaStream_t stream)
+    const T* biases, const T* residual, T* C, int m, int n, int k, int group_size, char* workspace_ptr,
+    const size_t workspace_bytes, cudaStream_t stream)
 {
-    if constexpr (std::is_same<Arch, cutlass::arch::Sm75>::value)
+    if constexpr (cutlass::isFinegrained(QuantOp) && Arch::kMinComputeCapability < 80)
     {
-        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm75, EpilogueOp, 2>(config.tile_config, A, B,
-            weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+        throw std::runtime_error("Fine grained kernels are only supported on Ampere and above.");
+        return;
+    }
+    else if constexpr (std::is_same<Arch, cutlass::arch::Sm75>::value)
+    {
+        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm75, QuantOp, EpilogueOp, 2>(config.tile_config, A, B,
+            weight_scales, biases, residual, C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
     }
     else if constexpr (std::is_same<Arch, cutlass::arch::Sm70>::value)
     {
-        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm70, EpilogueOp, 2>(config.tile_config, A, B,
-            weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm70, QuantOp, EpilogueOp, 2>(config.tile_config, A, B,
+            weight_scales, biases, residual, C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
     }
     else
     {
         if (config.stages == 3)
         {
-            dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp, 3>(config.tile_config, A, B, weight_scales, biases,
-                residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+            dispatch_gemm_residual<T, WeightType, Arch, QuantOp, EpilogueOp, 3>(config.tile_config, A, B, weight_scales,
+                biases, residual, C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
         }
         else if (config.stages == 4)
         {
-            dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp, 4>(config.tile_config, A, B, weight_scales, biases,
-                residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+            dispatch_gemm_residual<T, WeightType, Arch, QuantOp, EpilogueOp, 4>(config.tile_config, A, B, weight_scales,
+                biases, residual, C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
         }
         else
         { // 2
-            dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp, 2>(config.tile_config, A, B, weight_scales, biases,
-                residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+            dispatch_gemm_residual<T, WeightType, Arch, QuantOp, EpilogueOp, 2>(config.tile_config, A, B, weight_scales,
+                biases, residual, C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
         }
     }
 }
 
-template <typename T, typename WeightType, typename Arch, template <typename T_> class ActivationOp,
-    template <typename T_> class BinaryOp>
+template <typename T, typename WeightType, typename Arch, cutlass::WeightOnlyQuantOp QuantOp,
+    template <typename T_> class ActivationOp, template <typename T_> class BinaryOp>
 inline void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const WeightType* B, const T* weight_scales,
-    const T* biases, const T* residual, T* C, int m, int n, int k, const std::string& unary_op, char* workspace_ptr,
-    const size_t workspace_bytes, cudaStream_t stream)
+    const T* biases, const T* residual, T* C, int m, int n, int k, int group_size, const std::string& unary_op,
+    char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream)
 {
     using ElementOutput = T;
     using MixedGemmArchTraits = cutlass::gemm::kernel::MixedGemmArchTraits<T, WeightType, Arch>;
@@ -545,16 +607,16 @@ inline void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const W
         using EpilogueOp = cutlass::epilogue::thread::LinearCombinationResidualBlock<ElementOutput, ElementAccumulator,
             ElementAccumulator, ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value, ActivationOp, BinaryOp,
             cutlass::epilogue::thread::Identity>;
-        dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp>(
-            config, A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, Arch, QuantOp, EpilogueOp>(config, A, B, weight_scales, biases, residual,
+            C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
     }
     else if (unary_op == "relu")
     {
         using EpilogueOp = cutlass::epilogue::thread::LinearCombinationResidualBlock<ElementOutput, ElementAccumulator,
             ElementAccumulator, ElementOutput, 128 / cutlass::sizeof_bits<ElementOutput>::value, ActivationOp, BinaryOp,
             cutlass::epilogue::thread::ReLu>;
-        dispatch_gemm_residual<T, WeightType, Arch, EpilogueOp>(
-            config, A, B, weight_scales, biases, residual, C, m, n, k, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, Arch, QuantOp, EpilogueOp>(config, A, B, weight_scales, biases, residual,
+            C, m, n, k, group_size, workspace_ptr, workspace_bytes, stream);
     }
     else
     {
@@ -562,20 +624,21 @@ inline void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const W
     }
 }
 
-template <typename T, typename WeightType, typename Arch, template <typename T_> class ActivationOp>
+template <typename T, typename WeightType, typename Arch, cutlass::WeightOnlyQuantOp QuantOp,
+    template <typename T_> class ActivationOp>
 void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const WeightType* B, const T* weight_scales,
-    const T* biases, const T* residual, T* C, int m, int n, int k, const std::string& binary_op,
+    const T* biases, const T* residual, T* C, int m, int n, int k, int group_size, const std::string& binary_op,
     const std::string& unary_op, char* workspace_ptr, const size_t workspace_bytes, cudaStream_t stream)
 {
     if (binary_op == "plus")
     {
-        dispatch_gemm_residual<T, WeightType, Arch, ActivationOp, cutlass::plus>(config, A, B, weight_scales, biases,
-            residual, C, m, n, k, unary_op, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, Arch, QuantOp, ActivationOp, cutlass::plus>(config, A, B, weight_scales,
+            biases, residual, C, m, n, k, group_size, unary_op, workspace_ptr, workspace_bytes, stream);
     }
     else if (binary_op == "multiply")
     {
-        dispatch_gemm_residual<T, WeightType, Arch, ActivationOp, cutlass::multiplies>(config, A, B, weight_scales,
-            biases, residual, C, m, n, k, unary_op, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, Arch, QuantOp, ActivationOp, cutlass::multiplies>(config, A, B,
+            weight_scales, biases, residual, C, m, n, k, group_size, unary_op, workspace_ptr, workspace_bytes, stream);
     }
     else
     {
@@ -583,31 +646,35 @@ void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const WeightTy
     }
 }
 
-template <typename T, typename WeightType, typename Arch>
+template <typename T, typename WeightType, typename Arch, cutlass::WeightOnlyQuantOp QuantOp>
 void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const WeightType* B, const T* weight_scales,
-    const T* biases, const T* residual, T* C, int m, int n, int k, const std::string& activation,
+    const T* biases, const T* residual, T* C, int m, int n, int k, int group_size, const std::string& activation,
     const std::string& binary_op, const std::string& unary_op, char* workspace_ptr, const size_t workspace_bytes,
     cudaStream_t stream)
 {
     if (activation == "identity")
     {
-        dispatch_gemm_residual<T, WeightType, Arch, cutlass::epilogue::thread::Identity>(config, A, B, weight_scales,
-            biases, residual, C, m, n, k, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, Arch, QuantOp, cutlass::epilogue::thread::Identity>(config, A, B,
+            weight_scales, biases, residual, C, m, n, k, group_size, binary_op, unary_op, workspace_ptr,
+            workspace_bytes, stream);
     }
     else if ("silu")
     {
-        dispatch_gemm_residual<T, WeightType, Arch, cutlass::epilogue::thread::SiLu>(config, A, B, weight_scales,
-            biases, residual, C, m, n, k, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, Arch, QuantOp, cutlass::epilogue::thread::SiLu>(config, A, B,
+            weight_scales, biases, residual, C, m, n, k, group_size, binary_op, unary_op, workspace_ptr,
+            workspace_bytes, stream);
     }
     else if ("relu")
     {
-        dispatch_gemm_residual<T, WeightType, Arch, cutlass::epilogue::thread::ReLu>(config, A, B, weight_scales,
-            biases, residual, C, m, n, k, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, Arch, QuantOp, cutlass::epilogue::thread::ReLu>(config, A, B,
+            weight_scales, biases, residual, C, m, n, k, group_size, binary_op, unary_op, workspace_ptr,
+            workspace_bytes, stream);
     }
     else if ("gelu")
     {
-        dispatch_gemm_residual<T, WeightType, Arch, cutlass::epilogue::thread::GELU>(config, A, B, weight_scales,
-            biases, residual, C, m, n, k, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, Arch, QuantOp, cutlass::epilogue::thread::GELU>(config, A, B,
+            weight_scales, biases, residual, C, m, n, k, group_size, binary_op, unary_op, workspace_ptr,
+            workspace_bytes, stream);
     }
     else
     {
@@ -615,39 +682,39 @@ void dispatch_gemm_residual(CutlassGemmConfig config, const T* A, const WeightTy
     }
 }
 
-template <typename T, typename WeightType>
-void CutlassFpAIntBGemmRunner<T, WeightType>::gemm_bias_act_residual(const T* A, const WeightType* B,
-    const T* weight_scales, const T* biases, const T* residual, T* C, int m, int n, int k,
+template <typename T, typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
+void CutlassFpAIntBGemmRunner<T, WeightType, QuantOp>::gemm_bias_act_residual(const T* A, const WeightType* B,
+    const T* weight_scales, const T* biases, const T* residual, T* C, int m, int n, int k, int group_size,
     const std::string& activation, const std::string& binary_op, const std::string& unary_op, char* workspace_ptr,
     const size_t workspace_bytes, cudaStream_t stream)
 {
 
-    std::vector<CutlassGemmConfig> candidate_configs = get_candidate_configs(sm_, true, false);
+    std::vector<CutlassGemmConfig> candidate_configs = get_candidate_configs(sm_, true, QuantOp, false);
     std::vector<int> occupancies(candidate_configs.size());
 
     for (size_t ii = 0; ii < candidate_configs.size(); ++ii)
     {
-        dispatch_to_arch<EpilogueOpNoBias>(A, B, weight_scales, biases, C, m, n, k, 0, candidate_configs[ii],
-            workspace_ptr, workspace_bytes, stream, &occupancies[ii]);
+        dispatch_to_arch<EpilogueOpNoBias>(A, B, weight_scales, biases, C, m, n, k, group_size, 0,
+            candidate_configs[ii], workspace_ptr, workspace_bytes, stream, &occupancies[ii]);
     }
 
     CutlassGemmConfig chosen_config = estimate_best_config_from_occupancies(
-        candidate_configs, occupancies, m, n, k, 1, split_k_limit, workspace_bytes, multi_processor_count_, true);
+        candidate_configs, occupancies, m, n, k, 1, SPLIT_K_LIMIT, workspace_bytes, multi_processor_count_, true);
 
     if (sm_ >= 80 && sm_ < 90)
     {
-        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm80>(chosen_config, A, B, weight_scales, biases, residual,
-            C, m, n, k, activation, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm80, QuantOp>(chosen_config, A, B, weight_scales, biases,
+            residual, C, m, n, k, group_size, activation, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
     }
     else if (sm_ >= 75 && sm_ < 80)
     {
-        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm75>(chosen_config, A, B, weight_scales, biases, residual,
-            C, m, n, k, activation, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm75, QuantOp>(chosen_config, A, B, weight_scales, biases,
+            residual, C, m, n, k, group_size, activation, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
     }
     else if (sm_ == 70)
     {
-        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm70>(chosen_config, A, B, weight_scales, biases, residual,
-            C, m, n, k, activation, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
+        dispatch_gemm_residual<T, WeightType, cutlass::arch::Sm70, QuantOp>(chosen_config, A, B, weight_scales, biases,
+            residual, C, m, n, k, group_size, activation, binary_op, unary_op, workspace_ptr, workspace_bytes, stream);
     }
     else
     {
@@ -655,17 +722,16 @@ void CutlassFpAIntBGemmRunner<T, WeightType>::gemm_bias_act_residual(const T* A,
     }
 }
 
-template <typename T, typename WeightType>
-int CutlassFpAIntBGemmRunner<T, WeightType>::getWorkspaceSize(const int m, const int n, const int k)
+template <typename T, typename WeightType, cutlass::WeightOnlyQuantOp QuantOp>
+int CutlassFpAIntBGemmRunner<T, WeightType, QuantOp>::getWorkspaceSize(const int m, const int n, const int k)
 {
     FT_LOG_DEBUG(__PRETTY_FUNCTION__);
     // TODO(masahi): Shouldn't it be 0?
-
     // These are the min tile sizes for each config, which would launch the maximum number of blocks
-    const int max_grid_m = (m + 31) / 32;
-    const int max_grid_n = (n + 127) / 128;
+    const int max_grid_m = cutlass::ceil_div(m, MIN_M_TILE);
+    const int max_grid_n = cutlass::ceil_div(n, MIN_N_TILE);
     // We need 4 bytes per block in the worst case. We launch split_k_limit in z dim.
-    return max_grid_m * max_grid_n * split_k_limit * 4;
+    return static_cast<size_t>(max_grid_m * max_grid_n * SPLIT_K_LIMIT * 4);
 }
 
 } // namespace fastertransformer


### PR DESCRIPTION
This is 3/3 PR of integrating tensorrt-llm v0.5 fpA_intB_gemm kernels.

This PR added a new template param `QuantOp` to the APIs, which now supports both `PER_COLUMN_SCALE_ONLY` and `FINEGRAIND_SCALE_ONLY`.