### PR TITLE
Add weight only batched gemv kernels for small batch size

### DIFF
--- a/cutlass_kernels/CMakeLists.txt
+++ b/cutlass_kernels/CMakeLists.txt
@@ -27,4 +27,16 @@ set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -t 8 \
                       -gencode=arch=compute_80,code=\\\"sm_80,compute_80\\\" \
                       ")
 
-add_library(fpA_intB_gemm SHARED fpA_intB_gemm/fpA_intB_gemm_per_col.cu fpA_intB_gemm/fpA_intB_gemm_finegrained.cu  cutlass_heuristic.cc cutlass_preprocessors.cc ${CMAKE_CURRENT_SOURCE_DIR}/../utils/logger.cc ${CMAKE_CURRENT_SOURCE_DIR}/../utils/cuda_utils.cc)
+file(GLOB WEIGHT_ONLY_BATCHED_GEMV_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../weightOnlyBatchedGemv/*.cu)
+
+set(FPA_INTB_GEMM_SRC 
+    fpA_intB_gemm/fpA_intB_gemm_per_col.cu
+    fpA_intB_gemm/fpA_intB_gemm_finegrained.cu
+    cutlass_heuristic.cc
+    cutlass_preprocessors.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../utils/logger.cc
+    ${CMAKE_CURRENT_SOURCE_DIR}/../utils/cuda_utils.cc
+    ${WEIGHT_ONLY_BATCHED_GEMV_SRC}
+    )
+
+add_library(fpA_intB_gemm SHARED ${FPA_INTB_GEMM_SRC})

--- a/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm_impl.h
+++ b/cutlass_kernels/fpA_intB_gemm/fpA_intB_gemm_impl.h
@@ -45,7 +45,6 @@ void dispatch_to_weight_only_batched_gemv(const half* A, const WeightType* B, co
     int bias_stride, char* workspace_ptr, size_t workspace_bytes, cudaStream_t stream)
 {
     using namespace tensorrt_llm::kernels;
-    assert(bias_stride == 0);
 
     // Convert WeightType
     WeightOnlyQuantType weight_type
@@ -82,6 +81,7 @@ void dispatch_to_weight_only_batched_gemv(const half* A, const WeightType* B, co
         n,
         k,
         group_size,
+        bias_stride,
     };
 
     weight_only_batched_gemv_launcher(weight_type, quant_type, weight_only_activation, params, stream);

--- a/weightOnlyBatchedGemv/common.h
+++ b/weightOnlyBatchedGemv/common.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
+#include <iostream>
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+struct WeightOnlyParams
+{
+    const uint8_t* qweight;
+    const half* scales;
+    const half* zeros;
+    const half* in;
+    const half* bias;
+    half* out;
+    const int m;
+    const int n;
+    const int k;
+    const int group_size;
+
+    WeightOnlyParams(const uint8_t* _qweight, const half* _scales, const half* _zeros, const half* _in,
+        const half* _bias, half* _out, const int _m, const int _n, const int _k, const int _group_size)
+        : qweight(_qweight)
+        , scales(_scales)
+        , zeros(_zeros)
+        , in(_in)
+        , bias(_bias)
+        , out(_out)
+        , m(_m)
+        , n(_n)
+        , k(_k)
+        , group_size(_group_size)
+    {
+    }
+};
+enum class WeightOnlyQuantType
+{
+    Int4b,
+    Int8b
+};
+enum class WeightOnlyType
+{
+    PerChannel,
+    GroupWise
+};
+
+struct WeightOnlyPerChannel;
+template <int GS>
+struct WeightOnlyGroupWise;
+
+enum class WeightOnlyActivationType
+{
+    Gelu,
+    Relu,
+    Identity,
+    InvalidType
+};
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/common.h
+++ b/weightOnlyBatchedGemv/common.h
@@ -39,9 +39,11 @@ struct WeightOnlyParams
     const int n;
     const int k;
     const int group_size;
+    const int bias_stride;
 
     WeightOnlyParams(const uint8_t* _qweight, const half* _scales, const half* _zeros, const half* _in,
-        const half* _bias, half* _out, const int _m, const int _n, const int _k, const int _group_size)
+        const half* _bias, half* _out, const int _m, const int _n, const int _k, const int _group_size,
+        const int _bias_stride)
         : qweight(_qweight)
         , scales(_scales)
         , zeros(_zeros)
@@ -52,6 +54,7 @@ struct WeightOnlyParams
         , n(_n)
         , k(_k)
         , group_size(_group_size)
+        , bias_stride(_bias_stride)
     {
     }
 };

--- a/weightOnlyBatchedGemv/enabled.h
+++ b/weightOnlyBatchedGemv/enabled.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "utils/cuda_utils.h"
+#include "cutlass_extensions/include/cutlass_extensions/gemm/kernel/mixed_gemm_B_layout.h"
+#include "kernels/weightOnlyBatchedGemv/common.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+template <typename TypeB, typename Layout>
+struct SupportedLayout
+{
+    static constexpr bool value = false;
+};
+
+template <>
+struct SupportedLayout<uint8_t, cutlass::layout::ColumnMajorTileInterleave<64, 2>>
+{
+    static constexpr bool value = true;
+};
+
+template <>
+struct SupportedLayout<cutlass::uint4b_t, cutlass::layout::ColumnMajorTileInterleave<64, 4>>
+{
+    static constexpr bool value = true;
+};
+
+template <typename TypeB, typename Arch>
+bool isEnabled()
+{
+    using Layout = typename cutlass::gemm::kernel::LayoutDetailsB<TypeB, Arch>::Layout;
+    return SupportedLayout<TypeB, Layout>::value;
+}
+
+template <typename TypeB>
+bool isEnabledForArch(int arch)
+{
+    if (arch >= 70 && arch < 75)
+    {
+        return isEnabled<TypeB, cutlass::arch::Sm70>();
+    }
+    else if (arch >= 75 && arch < 80)
+    {
+        return isEnabled<TypeB, cutlass::arch::Sm75>();
+    }
+    else if (arch >= 80 && arch <= 90)
+    {
+        return isEnabled<TypeB, cutlass::arch::Sm80>();
+    }
+    else
+    {
+        TLLM_CHECK_WITH_INFO(false, "Unsupported Arch");
+        return false;
+    }
+}
+
+inline bool isWeightOnlyBatchedGemvEnabled(WeightOnlyQuantType qtype)
+{
+    const int arch = tensorrt_llm::common::getSMVersion();
+    if (qtype == WeightOnlyQuantType::Int4b)
+    {
+        return isEnabledForArch<cutlass::uint4b_t>(arch);
+    }
+    else if (qtype == WeightOnlyQuantType::Int8b)
+    {
+        return isEnabledForArch<uint8_t>(arch);
+    }
+    else
+    {
+        TLLM_CHECK_WITH_INFO(false, "Unsupported WeightOnlyQuantType");
+        return false;
+    }
+}
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/kernel.h
+++ b/weightOnlyBatchedGemv/kernel.h
@@ -1,0 +1,430 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include "weightOnlyBatchedGemv/common.h"
+#include "weightOnlyBatchedGemv/utility.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+template <WeightOnlyQuantType QType>
+struct WeightLayoutDetails;
+
+template <>
+struct WeightLayoutDetails<WeightOnlyQuantType::Int4b>
+{
+    // Every four rows of the original weights are interleaved into a row with stride of 64, so if each thread
+    // processes 32 elements(for int4, we can use ldg.128 to load weights), then every group of two adjacent threads
+    // will alternately process four different row weights
+    // for example
+    // every 256 consecutive int4 elements [256*i, 256*(i+1)-1] of row N under interleave layout,
+    // the first 64 are from [64*i, 64*(i+1)-1] of row 4N before interleaving,
+    // and the second 64 are from [64*i, 64*(i+1)-1] of row 4N+1 before interleaving, and so on.
+    // So if each thread loads 32 int4 elements, then the elements of each 2 adjacent threads of each 8
+    // consecutive threads will come from row 4N ~ 4N+3 respectively before interleaving.
+    static constexpr int kElemBits = 4;
+    static constexpr int kInterleave = 4;
+    static constexpr int kStride = 64;
+
+    // The index remapping here is to counteracts the effect of cutlass::permute_B_rows_for_mixed_gemm
+    // input 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 ... 31
+    // weight 0 1 8 9 16 17 24 25 2 3 10 11 18 19 26 27 4 5 12 13 20 21 28 29 6 7 14 15 22 23 30 31
+    static constexpr int kShuffleSize = 32;
+    static constexpr int kShuffleBasicTile = 2;
+    static constexpr int kShuffleContinous = 4;
+    static constexpr int kShuffleStrided = 4;
+
+    // The rearrangement here counteracts the effect of cutlass::add_bias_and_interleave_int4s_inplace
+    // Input int8 data layout
+    //      [elt_7  elt_5  elt_3  elt_1  elt_6  elt_4  elt_2  elt_0] (each elt occupies 4 bits)
+    //
+    // Converted fp16 data layout
+    //      [elt_7  elt_6  elt_5  elt_4  elt_3  elt_2  elt_1  elt_0] (each elt occupies 16 bits)
+    static constexpr int kConvertCount = 8;
+    using Converter
+        = cutlass::FastInterleavedAndBiasedNumericArrayConverter<cutlass::half_t, cutlass::uint4b_t, kConvertCount>;
+
+    // Each warp completes the internal reduce and writes the [Batch * NPerBlock * Interleave] results to the
+    // corresponding address in shared memory
+    template <int Num, int WarpSize>
+    __device__ __forceinline__ static void sync(float* res, float (*sm)[Num * kInterleave])
+    {
+#pragma unroll
+        for (int i = 0; i < Num; ++i)
+        {
+            res[i] += __shfl_xor_sync(~0, res[i], 16);
+            res[i] += __shfl_xor_sync(~0, res[i], 8);
+            res[i] += __shfl_xor_sync(~0, res[i], 1);
+        }
+        __syncthreads();
+        int warp = threadIdx.x / WarpSize, lane = threadIdx.x % WarpSize;
+        if (lane == 0 || lane == 2 || lane == 4 || lane == 6)
+        {
+#pragma unroll
+            for (int i = 0; i < Num; ++i)
+            {
+                sm[warp][i * kInterleave + lane / 2] = res[i];
+            }
+        }
+        __syncthreads();
+    }
+};
+
+template <>
+struct WeightLayoutDetails<WeightOnlyQuantType::Int8b>
+{
+    // Every two rows of the original weights are interleaved into a row with stride of 64, so if each thread
+    // processes 16 elements(for int8, we can use ldg.128 to load weights), then every group of four adjacent threads
+    // will alternately process two different row weights
+    // for example
+    // every 128 consecutive int8 elements [128*i, 128*(i+1)-1] of row N under interleave layout,
+    // the first 64 are from [64*i, 64*(i+1)-1] of row 2N before interleaving,
+    // and the last 64 are from [64*i, 64*(i+1)-1] of row 2N+1 before interleaving.
+    // So if each thread loads 16 int8 elements, then the elements of the first four and last four threads of each 8
+    // consecutive threads will come from row 2N and row 2N+1 respectively before interleaving.
+    static constexpr int kElemBits = 8;
+    static constexpr int kInterleave = 2;
+    static constexpr int kStride = 64;
+
+    // The index remapping here is to counteracts the effect of cutlass::permute_B_rows_for_mixed_gemm
+    // input 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
+    // weight 0 1 8 9 2 3 10 11 4 5 12 13 6 7 14 15
+    static constexpr int kShuffleSize = 16;
+    static constexpr int kShuffleBasicTile = 2;
+    static constexpr int kShuffleContinous = 2;
+    static constexpr int kShuffleStrided = 4;
+
+    // The rearrangement here counteracts the effect of cutlass::add_bias_and_interleave_int8s_inplace
+    // Input int8 data layout
+    //      [elt_3  elt_1  elt_2  elt_0] (each elt occupies 8 bits)
+    //
+    // Converted fp16 data layout
+    //      [elt_3  elt_2  elt_1  elt_0] (each elt occupies 16 bits)
+    static constexpr int kConvertCount = 4;
+    using Converter = cutlass::FastInterleavedAndBiasedNumericArrayConverter<cutlass::half_t, uint8_t, kConvertCount>;
+
+    // Each warp completes the internal reduce and writes the [Batch * NPerBlock * Interleave] results to the
+    // corresponding address in shared memory
+    template <int Num, int WarpSize>
+    __device__ __forceinline__ static void sync(float* res, float (*sm)[Num * kInterleave])
+    {
+#pragma unroll
+        for (int i = 0; i < Num; ++i)
+        {
+            res[i] += __shfl_xor_sync(~0, res[i], 16);
+            res[i] += __shfl_xor_sync(~0, res[i], 8);
+            res[i] += __shfl_xor_sync(~0, res[i], 2);
+            res[i] += __shfl_xor_sync(~0, res[i], 1);
+        }
+        __syncthreads();
+        int warp = threadIdx.x / WarpSize, lane = threadIdx.x % WarpSize;
+        if (lane == 0 || lane == 4)
+        {
+#pragma unroll
+            for (int i = 0; i < Num; ++i)
+            {
+                sm[warp][i * kInterleave + lane / 4] = res[i];
+            }
+        }
+        __syncthreads();
+    }
+};
+
+template <WeightOnlyQuantType QType>
+struct WeightOnlyKernelDetails
+{
+    using Layout = WeightLayoutDetails<QType>;
+
+    static constexpr int kElemBits = Layout::kElemBits;
+    static constexpr int kInterleave = Layout::kInterleave;
+    static constexpr int kStride = Layout::kStride;
+
+    static constexpr int kShuffleSize = Layout::kShuffleSize;
+    static constexpr int kShuffleBasicTile = Layout::kShuffleBasicTile;
+    static constexpr int kShuffleContinous = Layout::kShuffleContinous;
+    static constexpr int kShuffleStrided = Layout::kShuffleStrided;
+
+    using Converter = typename Layout::Converter;
+    static constexpr int kConvertCount = Layout::kConvertCount;
+
+    // Use ldg128 load data from global memory
+    static constexpr int kAccessSize = 128;
+    using AccessType = uint4;
+
+    static constexpr int kElemsPerByte = 8 / kElemBits;
+    static constexpr int kElemsPerThread = kAccessSize / kElemBits;
+    static constexpr int kBytePerThread = kElemsPerThread / kElemsPerByte;
+    static constexpr int kThreadsNumPerTile = kStride / kElemsPerThread;
+    static constexpr int kThreadsNumPerInterleave = kThreadsNumPerTile * kInterleave;
+
+    static constexpr int kConvertIters = kElemsPerThread / kConvertCount;
+
+    // Each thread loads 16(int8b)/32(int4b) quantized weight elements each time through ldg128
+    // So more times of ldg128 are needed to load the same number of fp16 activation elements.
+    static constexpr int kActivationElemNumPerAccess = kAccessSize / (sizeof(half) * 8);
+    static constexpr int kActivationAccessNum = kElemsPerThread / kActivationElemNumPerAccess;
+};
+
+template <typename WeightOnlyFlag>
+struct WeightOnlyProperties;
+
+template <>
+struct WeightOnlyProperties<WeightOnlyPerChannel>
+{
+    static constexpr bool kIsFineGrained = false;
+    static constexpr int kGroupSize = 0;
+};
+
+template <int GS>
+struct WeightOnlyProperties<WeightOnlyGroupWise<GS>>
+{
+    static constexpr bool kIsFineGrained = true;
+    static constexpr int kGroupSize = GS;
+};
+
+template <WeightOnlyQuantType QType, typename WeightOnlyFlag, bool Zero, int BlockSize>
+struct WeightOnlyScaleLoader
+{
+    using ElemType = half;
+    using Details = WeightOnlyKernelDetails<QType>;
+    static constexpr bool kIsFineGrained = WeightOnlyProperties<WeightOnlyFlag>::kIsFineGrained;
+    static constexpr int kGroupSize = WeightOnlyProperties<WeightOnlyFlag>::kGroupSize;
+
+private:
+    const ElemType* _scales;
+    const ElemType* _zeros;
+    int _stride;
+    int _offset;
+
+public:
+    __device__ __forceinline__ WeightOnlyScaleLoader(
+        const ElemType* scales, const ElemType* zeros, int initial_offset, int stride)
+        : _scales(scales)
+        , _zeros(zeros)
+        , _stride(stride)
+    {
+        _scales += initial_offset;
+        if constexpr (Zero)
+        {
+            _zeros += initial_offset;
+        }
+        // Calculate the k dimension index of the element processed by the current thread of layout before interleave
+        // Used to load scales and zeros in groupwise weight only quant
+        _offset = threadIdx.x / Details::kThreadsNumPerInterleave * Details::kStride
+            + (threadIdx.x % Details::kThreadsNumPerTile) * Details::kElemsPerThread;
+    }
+
+    __device__ __forceinline__ void load(ElemType& scale, ElemType& zero, int nid)
+    {
+        int offset = nid * Details::kInterleave;
+        if constexpr (kIsFineGrained)
+        {
+            offset += _offset / kGroupSize * _stride;
+        }
+        scale = _scales[offset];
+        if constexpr (Zero)
+        {
+            zero = _zeros[offset];
+        }
+        else
+        {
+            zero = static_cast<ElemType>(0.f);
+        }
+    }
+
+    __device__ __forceinline__ void advance()
+    {
+        _offset += BlockSize * Details::kElemsPerThread / Details::kInterleave;
+    }
+
+    __device__ __forceinline__ int offset()
+    {
+        return _offset;
+    }
+};
+
+template <WeightOnlyQuantType QType, typename WeightOnlyFlag, template <typename T> class ActOp, bool Zero, bool Bias,
+    int NPerBlock, int Batch, int BlockSize>
+__global__ void weight_only_batched_gemv(const uint8_t* qweight, const half* scales, const half* zeros, const half* in,
+    const half* bias, half* out, const int n, const int k)
+{
+    static_assert(NPerBlock == 1 || (NPerBlock % 2 == 0));
+    using Details = WeightOnlyKernelDetails<QType>;
+
+    using Converter = typename Details::Converter;
+    using AccType = typename Details::AccessType;
+    using CvtSrcType = typename Converter::source_type;
+    using CvtResType = typename Converter::result_type;
+    using ScaleLoader = WeightOnlyScaleLoader<QType, WeightOnlyFlag, Zero, BlockSize>;
+    extern __shared__ uint8_t shmem[];
+    constexpr int Interleave = Details::kInterleave;
+    constexpr int WarpSize = 32;
+    constexpr int Num = Batch * NPerBlock;
+    const int tid = threadIdx.x;
+    const int bid = blockIdx.x;
+    const int n_start_id = bid * NPerBlock * Interleave;
+    // Calculate the n-dimensional index of the data processed by the current thread in the interleave tile
+    const int interleave_n_id = (tid / Details::kThreadsNumPerTile) % Interleave;
+
+    qweight += n_start_id * k / Details::kElemsPerByte;
+    ScaleLoader scale_loader(scales, zeros, n_start_id + interleave_n_id, n);
+
+    float(*sm)[Num * Interleave] = reinterpret_cast<float(*)[Num * Interleave]>(shmem);
+
+    // In order to take advantage of hfma2, we use fp16 for accumulation within threads and fp32 for accumulation
+    // between threads.
+    half accumulator[Num];
+    for (int i = 0; i < Num; ++i)
+    {
+        accumulator[i] = __float2half_rn(0.f);
+    }
+
+    // Iteration in k dimensions
+    for (int local_k = tid * Details::kElemsPerThread; local_k < k * Interleave;
+         local_k += BlockSize * Details::kElemsPerThread)
+    {
+        half weights_f16[Details::kElemsPerThread * NPerBlock];
+        half scale[NPerBlock], zero[NPerBlock];
+#pragma unroll
+        for (int idx = 0; idx < NPerBlock; ++idx)
+        {
+            // Load quantized weight and scales/zeros
+            uint8_t weights_quantized[Details::kBytePerThread];
+            load<AccType>(weights_quantized,
+                qweight + idx * Interleave * k / Details::kElemsPerByte + local_k / Details::kElemsPerByte);
+            scale_loader.load(scale[idx], zero[idx], idx);
+            half weights_vec[Details::kElemsPerThread];
+#pragma unroll
+            for (int i = 0; i < Details::kConvertIters; ++i)
+            {
+                // Use cutlass::FastInterleavedAndBiasedNumericArrayConverter for I2F type conversion
+                assign<CvtResType>(weights_vec + i * Details::kConvertCount,
+                    Converter::convert(*reinterpret_cast<CvtSrcType*>(
+                        weights_quantized + i * Details::kConvertCount / Details::kElemsPerByte)));
+            }
+#pragma unroll
+            for (int i = 0; i < Details::kShuffleContinous; ++i)
+            {
+#pragma unroll
+                for (int j = 0; j < Details::kShuffleStrided; ++j)
+                {
+                    // Dequantize the weights and arrange the shuffled elements back to the correct order in the
+                    // register array
+                    half2 v = *reinterpret_cast<half2*>(weights_vec + i * Details::kShuffleBasicTile
+                        + j * Details::kShuffleContinous * Details::kShuffleBasicTile);
+                    v = __hfma2(v, __half2half2(scale[idx]), __half2half2(zero[idx]));
+                    weights_f16[(i * Details::kShuffleStrided * Details::kShuffleBasicTile
+                                    + j * Details::kShuffleBasicTile + 0)
+                            * NPerBlock
+                        + idx]
+                        = v.x;
+                    weights_f16[(i * Details::kShuffleStrided * Details::kShuffleBasicTile
+                                    + j * Details::kShuffleBasicTile + 1)
+                            * NPerBlock
+                        + idx]
+                        = v.y;
+                }
+            }
+        }
+#pragma unroll
+        for (int b = 0; b < Batch; ++b)
+        {
+            half in_v[Details::kElemsPerThread];
+#pragma unroll
+            for (int idx = 0; idx < Details::kActivationAccessNum; ++idx)
+            {
+                // load activation elements
+                load<AccType>(in_v + idx * Details::kActivationElemNumPerAccess,
+                    in + b * k + scale_loader.offset() + idx * Details::kActivationElemNumPerAccess);
+            }
+            // Perform vector inner product and accumulate
+            if constexpr (NPerBlock == 1)
+            {
+                half2 v = __float2half2_rn(0.f);
+#pragma unroll
+                for (int y = 0; y < Details::kElemsPerThread; y += 2)
+                {
+                    v = __hfma2(*reinterpret_cast<half2*>(weights_f16 + y), *reinterpret_cast<half2*>(in_v + y), v);
+                }
+                accumulator[b] += __hadd(v.x, v.y);
+            }
+            else
+            {
+#pragma unroll
+                for (int x = 0; x < NPerBlock / 2; ++x)
+                {
+#pragma unroll
+                    for (int y = 0; y < Details::kElemsPerThread; ++y)
+                    {
+                        *reinterpret_cast<half2*>(accumulator + b * NPerBlock + x * 2)
+                            = __hfma2(*reinterpret_cast<half2*>(weights_f16 + y * NPerBlock + x * 2),
+                                __half2half2(in_v[y]), *reinterpret_cast<half2*>(accumulator + b * NPerBlock + x * 2));
+                    }
+                }
+            }
+        }
+        scale_loader.advance();
+    }
+    float reses[Num];
+#pragma unroll
+    for (int i = 0; i < Num; ++i)
+    {
+        reses[i] = __half2float(accumulator[i]);
+    }
+
+    // Each warp completes the internal reduce and writes the [Batch * NPerBlock * Interleave] results to the
+    // corresponding address in shared memory
+    Details::Layout::sync<Num, WarpSize>(reses, sm);
+
+    // Each thread is responsible for the accumulation and store to global memory of one element
+    for (int i = tid; i < Num * Interleave; i += BlockSize)
+    {
+        int nid = i % (NPerBlock * Interleave);
+        float v = 0.f;
+        for (int j = 0; j < BlockSize / WarpSize; ++j)
+        {
+            v += sm[j][i];
+        }
+        float bias_v = 0.f;
+        if constexpr (Bias)
+        {
+            bias_v = __half2float(bias[n_start_id + nid]);
+        }
+        int b = i / NPerBlock / Interleave;
+        out[b * n + n_start_id + nid] = __float2half_rn(ActOp<float>::apply(v + bias_v));
+    }
+}
+
+template <WeightOnlyQuantType QType, typename WeightOnlyFlag, template <typename T> class ActOp, bool Zero, bool Bias,
+    int NPerBlock, int Batch, int BlockSize>
+struct WeightOnlyBatchedGemvKernelLauncher
+{
+    static constexpr int kInterleave = WeightLayoutDetails<QType>::kInterleave;
+
+    static void run(const WeightOnlyParams& params, cudaStream_t stream)
+    {
+        dim3 grid(params.n / NPerBlock / kInterleave);
+        dim3 block(BlockSize);
+        int size = sizeof(float) * BlockSize / 32 * Batch * NPerBlock * kInterleave;
+        weight_only_batched_gemv<QType, WeightOnlyFlag, ActOp, Zero, Bias, NPerBlock, Batch, BlockSize>
+            <<<grid, block, size, stream>>>(
+                params.qweight, params.scales, params.zeros, params.in, params.bias, params.out, params.n, params.k);
+    }
+};
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/kernelLauncher.cu
+++ b/weightOnlyBatchedGemv/kernelLauncher.cu
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "weightOnlyBatchedGemv/common.h"
+#include "weightOnlyBatchedGemv/utility.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+template <WeightOnlyQuantType QType, typename WeightOnlyFlag, template <typename T> class ActOp, bool Zero, bool Bias,
+    int N_PER_BLOCK, int BATCH, int BLOCK_SIZE>
+struct WeightOnlyBatchedGemvKernelLauncher
+{
+    static void run(const WeightOnlyParams& params, cudaStream_t stream);
+};
+
+template <WeightOnlyQuantType QType, typename WeightOnlyFlag, template <typename T> class ActOp, int N_PER_BLOCK,
+    int BATCH, int BLOCK_SIZE>
+void select_zero_bias(const WeightOnlyParams& params, cudaStream_t stream)
+{
+    if (params.zeros && params.bias)
+    {
+        WeightOnlyBatchedGemvKernelLauncher<QType, WeightOnlyFlag, ActOp, true, true, N_PER_BLOCK, BATCH,
+            BLOCK_SIZE>::run(params, stream);
+    }
+    else if (params.zeros && !params.bias)
+    {
+        WeightOnlyBatchedGemvKernelLauncher<QType, WeightOnlyFlag, ActOp, true, false, N_PER_BLOCK, BATCH,
+            BLOCK_SIZE>::run(params, stream);
+    }
+    else if (!params.zeros && params.bias)
+    {
+        WeightOnlyBatchedGemvKernelLauncher<QType, WeightOnlyFlag, ActOp, false, true, N_PER_BLOCK, BATCH,
+            BLOCK_SIZE>::run(params, stream);
+    }
+    else
+    {
+        WeightOnlyBatchedGemvKernelLauncher<QType, WeightOnlyFlag, ActOp, false, false, N_PER_BLOCK, BATCH,
+            BLOCK_SIZE>::run(params, stream);
+    }
+}
+
+template <WeightOnlyQuantType QType, typename WeightOnlyFlag, int N_PER_BLOCK, int BATCH, int BLOCK_SIZE>
+void select_activation(WeightOnlyActivationType atype, const WeightOnlyParams& params, cudaStream_t stream)
+{
+    switch (atype)
+    {
+    case WeightOnlyActivationType::Gelu:
+    {
+        select_zero_bias<QType, WeightOnlyFlag, GeluActivation, N_PER_BLOCK, BATCH, BLOCK_SIZE>(params, stream);
+        break;
+    }
+    case WeightOnlyActivationType::Relu:
+    {
+        select_zero_bias<QType, WeightOnlyFlag, ReluActivation, N_PER_BLOCK, BATCH, BLOCK_SIZE>(params, stream);
+        break;
+    }
+    case WeightOnlyActivationType::Identity:
+    {
+        select_zero_bias<QType, WeightOnlyFlag, IdentityActivation, N_PER_BLOCK, BATCH, BLOCK_SIZE>(params, stream);
+        break;
+    }
+    default:
+    {
+        throw std::runtime_error("Use unsupported activation");
+        break;
+    }
+    }
+}
+
+template <typename WeightOnlyFlag, int N_PER_BLOCK, int BATCH, int BLOCK_SIZE>
+void select_quant_type(
+    WeightOnlyQuantType qtype, WeightOnlyActivationType atype, const WeightOnlyParams& params, cudaStream_t stream)
+{
+    if (qtype == WeightOnlyQuantType::Int4b)
+    {
+        select_activation<WeightOnlyQuantType::Int4b, WeightOnlyFlag, N_PER_BLOCK, BATCH, BLOCK_SIZE>(
+            atype, params, stream);
+    }
+    else if (qtype == WeightOnlyQuantType::Int8b)
+    {
+        select_activation<WeightOnlyQuantType::Int8b, WeightOnlyFlag, N_PER_BLOCK, BATCH, BLOCK_SIZE>(
+            atype, params, stream);
+    }
+    else
+    {
+        throw std::runtime_error("Unknown QuantType");
+    }
+}
+
+template <int N_PER_BLOCK, int BATCH, int BLOCK_SIZE>
+void select_groupwise_weight_only(WeightOnlyQuantType qtype, WeightOnlyType wtype, WeightOnlyActivationType atype,
+    const WeightOnlyParams& params, cudaStream_t stream)
+{
+    if (wtype == WeightOnlyType::GroupWise && params.group_size == 64)
+    {
+        select_quant_type<WeightOnlyGroupWise<64>, N_PER_BLOCK, BATCH, BLOCK_SIZE>(qtype, atype, params, stream);
+    }
+    else if (wtype == WeightOnlyType::GroupWise && params.group_size == 128)
+    {
+        select_quant_type<WeightOnlyGroupWise<128>, N_PER_BLOCK, BATCH, BLOCK_SIZE>(qtype, atype, params, stream);
+    }
+    else
+    {
+        throw std::runtime_error("Only support groupwise weight only for gs=64/128");
+    }
+}
+
+void weight_only_batched_gemv_launcher(WeightOnlyQuantType qtype, WeightOnlyType wtype, WeightOnlyActivationType atype,
+    const WeightOnlyParams& params, cudaStream_t stream)
+{
+    if (wtype == WeightOnlyType::PerChannel)
+    {
+        if (qtype == WeightOnlyQuantType::Int4b)
+        {
+            switch (params.m)
+            {
+            case 1:
+            {
+                select_activation<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, 1, 1, 192>(atype, params, stream);
+                break;
+            }
+            case 2:
+            {
+                select_activation<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, 2, 2, 128>(atype, params, stream);
+                break;
+            }
+            case 3:
+            {
+                select_activation<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, 2, 3, 256>(atype, params, stream);
+                break;
+            }
+            case 4:
+            {
+                select_activation<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, 4, 4, 256>(atype, params, stream);
+                break;
+            }
+            default:
+            {
+                throw std::runtime_error("Weight only cuda kernel only supported bs <= 4");
+                break;
+            }
+            }
+        }
+        else if (qtype == WeightOnlyQuantType::Int8b)
+        {
+            switch (params.m)
+            {
+            case 1:
+            {
+                select_activation<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, 2, 1, 256>(atype, params, stream);
+                break;
+            }
+            case 2:
+            {
+                select_activation<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, 2, 2, 256>(atype, params, stream);
+                break;
+            }
+            case 3:
+            {
+                select_activation<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, 2, 3, 256>(atype, params, stream);
+                break;
+            }
+            case 4:
+            {
+                select_activation<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, 2, 4, 256>(atype, params, stream);
+                break;
+            }
+            default:
+            {
+                throw std::runtime_error("Weight only cuda kernel only supported bs <= 4");
+                break;
+            }
+            }
+        }
+    }
+    else if (wtype == WeightOnlyType::GroupWise)
+    {
+        switch (params.m)
+        {
+        case 1:
+        {
+            select_groupwise_weight_only<2, 1, 256>(qtype, wtype, atype, params, stream);
+            break;
+        }
+        case 2:
+        {
+            select_groupwise_weight_only<2, 2, 256>(qtype, wtype, atype, params, stream);
+            break;
+        }
+        case 3:
+        {
+            select_groupwise_weight_only<2, 3, 128>(qtype, wtype, atype, params, stream);
+            break;
+        }
+        case 4:
+        {
+            select_groupwise_weight_only<2, 4, 128>(qtype, wtype, atype, params, stream);
+            break;
+        }
+        default:
+        {
+            throw std::runtime_error("Weight only cuda kernel only supported bs <= 4");
+            break;
+        }
+        }
+    }
+}
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/kernelLauncher.h
+++ b/weightOnlyBatchedGemv/kernelLauncher.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "weightOnlyBatchedGemv/common.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+void weight_only_batched_gemv_launcher(WeightOnlyQuantType qtype, WeightOnlyType wtype, WeightOnlyActivationType atype,
+    const WeightOnlyParams& params, cudaStream_t stream);
+}
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/utility.h
+++ b/weightOnlyBatchedGemv/utility.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cuda_runtime_api.h>
+#include <iostream>
+
+#include "cutlass/cutlass.h"
+#include "cutlass_extensions/interleaved_numeric_conversion.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+__forceinline__ __device__ float copysignf_pos(float a, float b)
+{
+    float r;
+    r = __int_as_float(__float_as_int(a) | (__float_as_int(b) & 0x80000000));
+    return r;
+}
+
+__inline__ __device__ float tanh_opt(float x)
+{
+#if (__CUDA_ARCH__ >= 750 && CUDART_VERSION >= 11000)
+    float r;
+    asm("tanh.approx.f32 %0,%1; \n\t" : "=f"(r) : "f"(x));
+    return r;
+#else
+    const float exp_val = -1.f * fabs(2 * x);
+    return copysignf_pos((1.0f - __expf(exp_val)) / (__expf(exp_val) + 1.0f), x);
+#endif
+}
+
+template <typename T>
+struct GeluActivation
+{
+    static __device__ __forceinline__ T apply(const T& val)
+    {
+        const float cdf = 0.5f * (1.0f + tanh_opt((0.7978845608028654f * (val + 0.044715f * val * val * val))));
+        return val * cdf;
+    }
+};
+
+template <typename T>
+struct ReluActivation
+{
+    static __device__ __forceinline__ T apply(const T& val)
+    {
+        return val > static_cast<T>(0.0f) ? val : static_cast<T>(0.0f);
+    }
+};
+
+template <typename T>
+struct IdentityActivation
+{
+    static __device__ __forceinline__ T apply(const T& val)
+    {
+        return val;
+    }
+};
+
+template <typename VecType, typename T0, typename T1>
+__device__ __forceinline__ void load(T0* dst, T1* src, size_t offset = 0)
+{
+    *reinterpret_cast<VecType*>(dst) = *(reinterpret_cast<const VecType*>(src) + offset);
+}
+
+template <typename AssignType, typename T>
+__device__ __forceinline__ void assign(T* dst, const AssignType& val)
+{
+    *reinterpret_cast<AssignType*>(dst) = val;
+}
+
+template <typename VecType, typename T0, typename T1>
+__device__ __forceinline__ void store(T0* src, T1* dst, size_t offset = 0)
+{
+    *(reinterpret_cast<VecType*>(dst) + offset) = *reinterpret_cast<const VecType*>(src);
+}
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs1Int4b.cu
+++ b/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs1Int4b.cu
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "weightOnlyBatchedGemv/kernel.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    true, true, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    true, false, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    false, true, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    false, false, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    true, true, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    true, false, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    false, true, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    false, false, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, true, true, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, true, false, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, false, true, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, false, false, 1, 1, 192>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, false, 2, 1, 256>;
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs1Int8b.cu
+++ b/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs1Int8b.cu
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "weightOnlyBatchedGemv/kernel.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, false, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, true, 2, 1, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, false, 2, 1, 256>;
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs2Int4b.cu
+++ b/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs2Int4b.cu
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "weightOnlyBatchedGemv/kernel.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    true, true, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    true, false, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    false, true, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    false, false, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    true, true, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    true, false, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    false, true, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    false, false, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, true, true, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, true, false, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, false, true, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, false, false, 2, 2, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, false, 2, 2, 256>;
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs2Int8b.cu
+++ b/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs2Int8b.cu
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "weightOnlyBatchedGemv/kernel.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, false, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, true, 2, 2, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, false, 2, 2, 256>;
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs3Int4b.cu
+++ b/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs3Int4b.cu
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "weightOnlyBatchedGemv/kernel.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    true, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    true, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    false, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    false, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    true, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    true, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    false, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    false, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, true, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, true, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, false, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, false, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, false, 2, 3, 128>;
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs3Int8b.cu
+++ b/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs3Int8b.cu
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "weightOnlyBatchedGemv/kernel.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    true, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    true, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    false, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    false, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    true, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    true, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    false, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    false, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, true, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, true, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, false, true, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, false, false, 2, 3, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, false, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, true, 2, 3, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, false, 2, 3, 128>;
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs4Int4b.cu
+++ b/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs4Int4b.cu
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "weightOnlyBatchedGemv/kernel.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    true, true, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    true, false, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    false, true, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, GeluActivation,
+    false, false, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    true, true, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    true, false, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    false, true, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel, ReluActivation,
+    false, false, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, true, true, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, true, false, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, false, true, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyPerChannel,
+    IdentityActivation, false, false, 4, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int4b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, false, 2, 4, 128>;
+
+} // namespace kernels
+} // namespace tensorrt_llm

--- a/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs4Int8b.cu
+++ b/weightOnlyBatchedGemv/weightOnlyBatchedGemvBs4Int8b.cu
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2022-2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "weightOnlyBatchedGemv/kernel.h"
+
+namespace tensorrt_llm
+{
+namespace kernels
+{
+
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    true, true, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    true, false, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    false, true, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, GeluActivation,
+    false, false, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    true, true, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    true, false, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    false, true, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel, ReluActivation,
+    false, false, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, true, true, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, true, false, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, false, true, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyPerChannel,
+    IdentityActivation, false, false, 2, 4, 256>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, GeluActivation,
+    false, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>, ReluActivation,
+    false, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<64>,
+    IdentityActivation, false, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    GeluActivation, false, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    ReluActivation, false, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, true, false, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, true, 2, 4, 128>;
+template struct WeightOnlyBatchedGemvKernelLauncher<WeightOnlyQuantType::Int8b, WeightOnlyGroupWise<128>,
+    IdentityActivation, false, false, 2, 4, 128>;
+
+} // namespace kernels
+} // namespace tensorrt_llm


### PR DESCRIPTION
Add tensorrt-llm kernels for dispatching for batch <= 4. bias_stride is supported but residual is not supported yet.

Performance of single batch llama13B q4 on A100:
q4f16_1: 118 tok/s
q4f16_ft_group (before): 89 toks/s
q4f16_ft_group (this pr): 147 toks/s

cc @masahi 