### PR TITLE
Remove Hardcoded `CMAKE_CUDA_FLAGS`

### DIFF
--- a/cutlass_kernels/CMakeLists.txt
+++ b/cutlass_kernels/CMakeLists.txt
@@ -20,13 +20,6 @@ include_directories(../)
 include_directories(${CUDA_TOOLKIT_ROOT_DIR}/include)
 link_directories(${CUDA_TOOLKIT_ROOT_DIR}/lib64)
 
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -t 8 \
-                      --expt-relaxed-constexpr \
-                      -gencode=arch=compute_70,code=\\\"sm_70,compute_70\\\" \
-                      -gencode=arch=compute_75,code=\\\"sm_75,compute_75\\\" \
-                      -gencode=arch=compute_80,code=\\\"sm_80,compute_80\\\" \
-                      ")
-
 file(GLOB WEIGHT_ONLY_BATCHED_GEMV_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../weightOnlyBatchedGemv/*.cu)
 
 file(GLOB MOE_GEMM_SRC moe_gemm/*.cu)

--- a/cutlass_kernels/CMakeLists.txt
+++ b/cutlass_kernels/CMakeLists.txt
@@ -36,3 +36,7 @@ set(FPA_INTB_GEMM_SRC
     )
 
 add_library(fpA_intB_gemm SHARED ${FPA_INTB_GEMM_SRC})
+target_compile_options(
+  fpA_intB_gemm PRIVATE
+  $<$<COMPILE_LANGUAGE:CUDA>:-expt-relaxed-constexpr>
+)


### PR DESCRIPTION
It should be set in `config.cmake` or command line via two separate flags:

```cmake
set(CMAKE_CUDA_ARCHITECTURES "70;75;80")
set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -expt-relaxed-constexpr -t 8")
```

or 

```bash
cmake .. -DCMAKE_CUDA_ARCHITECTURES "70;75;80" -DCMAKE_CUDA_FLAGS "-expt-relaxed-constexpr -t 8"
```


CC: @masahi @vinx13