### PR TITLE
Use SM80's layout info for 90+ arch

### DIFF
--- a/cutlass_kernels/cutlass_preprocessors.cc
+++ b/cutlass_kernels/cutlass_preprocessors.cc
@@ -139,6 +139,11 @@ LayoutDetails getLayoutDetailsForTransform(QuantType quant_type, int arch)
     {
         return getLayoutDetailsForArch<cutlass::arch::Sm80>(quant_type);
     }
+    else if (arch >= 90 && arch < 110)
+    {
+        FT_LOG_WARNING("Using SM80's layout information for your architecture.");
+        return getLayoutDetailsForArch<cutlass::arch::Sm80>(quant_type);
+    }
     else
     {
         FT_CHECK_WITH_INFO(false, "Unsupported Arch");


### PR DESCRIPTION
Use SM80 for architectures 90+ in LayoutDetails as a temporary workaround to support architectures like SM100. Since the repository relies on CUTLASS, addressing broken APIs in the latest versions requires extra effort. Contributions from anyone interested would be greatly appreciated.

cc: @vinx13 @masahi @tqchen 